### PR TITLE
feat(licenseBrowser): add license browser page

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -30,6 +30,7 @@ import Browse from "./pages/Browse";
 import Search from "./pages/Search";
 import Login from "./pages/Login";
 import Overview from "./pages/Help/Overview";
+import LicenseBrowser from "./pages/Help/LicenseBrowser";
 
 // Routes imports
 import { routes } from "./constants/routes";
@@ -41,6 +42,11 @@ const Routes = () => {
         <PublicLayout exact path={routes.home} component={Home} />
         <PublicLayout exact path={routes.login} component={Login} />
         <PublicLayout exact path={routes.help.overview} component={Overview} />
+        <PublicLayout
+          exact
+          path={routes.help.licenseBrowser}
+          component={LicenseBrowser}
+        />
         <PrivateLayout exact path={routes.search} component={Search} />
         <PrivateLayout exact path={routes.browse} component={Browse} />
       </Switch>

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -76,6 +76,9 @@ const Header = () => {
               <Dropdown.Item href={routes.help.overview}>
                 Getting Started
               </Dropdown.Item>
+              <Dropdown.Item href={routes.help.licenseBrowser}>
+                License Browser
+              </Dropdown.Item>
             </Dropdown.Menu>
           </Dropdown>
           <PersonCircle color="#fff" size={40} className="ml-3" />

--- a/src/pages/Help/LicenseBrowser/index.js
+++ b/src/pages/Help/LicenseBrowser/index.js
@@ -19,7 +19,38 @@
 import React from "react";
 
 const LicenseBrowser = () => {
-  return <div>LicenseBrowser</div>;
+  return (
+    <div className="main-container my-3">
+      <p>On the top, you see for each scanner ...</p>
+      <ul className="triangle-bullets">
+        <li>if it ever run on this upload</li>
+        <li>the revision of the latest results</li>
+        <li>the newest revision</li>
+        <li>
+          a link to restart the scanner if latest results are not from newest
+          revision
+        </li>
+      </ul>
+      <p>
+        If there are results from different revisions, you can select the
+        results of these runs.
+      </p>
+      <p>
+        On the left side, you see a list of all found licenses. The counters
+        show how often a license is found by scanners and how often it was
+        concluded. Click on the license name to search for where the license is
+        found in the file listing.
+      </p>
+      <p>
+        On the right side, you see a list of all files or directories in the
+        current directory. You also the licenses found by any scanner and what
+        scanners found it. Also old results may be included if they differ from
+        current revision of the scanner. Results from an older version are
+        marked. You can search for any string in the file names or license
+        names.
+      </p>
+    </div>
+  );
 };
 
 export default LicenseBrowser;

--- a/src/pages/Help/Overview/index.js
+++ b/src/pages/Help/Overview/index.js
@@ -23,7 +23,7 @@ import fossologyFlow from "../../../assets/images/fossologyFlow.svg";
 
 const Overview = () => {
   return (
-    <div className="m-3">
+    <div className="main-container my-3">
       <div>
         <h2 className="text-primary-color font-size-sub-heading">
           The FOSSology Toolset

--- a/src/pages/Home/index.js
+++ b/src/pages/Home/index.js
@@ -51,7 +51,7 @@ const Home = () => {
       <div className="main-container my-5">
         <b className="font-size-medium">FOSSology</b> is a framework for
         software analysis tools. With it, you can:
-        <ul className="my-3">
+        <ul className="my-3 list-unstyled">
           <li>Upload files into the fossology repository.</li>
           <li>
             Unpack files (zip, tar, bz2, iso's, and many others) into its

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -29,7 +29,6 @@
   width: 95%;
   margin: auto;
 }
-
 /* font size */
 .font-size-small {
   font-size: 0.875rem;
@@ -45,9 +44,6 @@
 }
 
 /* Utility Classes */
-li {
-  list-style: none;
-}
 .triangle-bullets {
   list-style-type: disclosure-closed;
 }


### PR DESCRIPTION
## Description

Added license browser page

### Changes

- Added license browser page
- Added main-container class to all help pages to ensure uniform styling

## How to test

- Go to `http://localhost:3000/help/licenseBrowser`

## Screenshots

![image](https://user-images.githubusercontent.com/54680709/122857558-4983c800-d336-11eb-8100-52fcfc4f2d1f.png)


