### PR TITLE
feat(importReport): added the report import page of uploads

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -34,6 +34,7 @@ import LicenseBrowser from "./pages/Help/LicenseBrowser";
 import Instructions from "./pages/Upload/Instructions";
 import About from "./pages/Help/About";
 import ThirdPartyLicenses from "./pages/Help/ThirdPartyLicenses";
+import ImportReport from "./pages/Upload/ImportReport";
 
 // Routes imports
 import { routes } from "./constants/routes";
@@ -63,6 +64,11 @@ const Routes = () => {
         />
         <PrivateLayout exact path={routes.search} component={Search} />
         <PrivateLayout exact path={routes.browse} component={Browse} />
+        <PrivateLayout
+          exact
+          path={routes.upload.report}
+          component={ImportReport}
+        />
       </Switch>
     </BrowserRouter>
   );

--- a/src/components/Widgets/Input/index.js
+++ b/src/components/Widgets/Input/index.js
@@ -1,0 +1,87 @@
+/*
+ Copyright (C) 2021 Shruti Agarwal (mail2shruti.ag@gmail.com)
+
+ SPDX-License-Identifier: GPL-2.0
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+import React from "react";
+import PropTypes from "prop-types";
+
+const InputContainer = ({
+  type,
+  name,
+  value,
+  id,
+  className,
+  onChange,
+  children,
+  checked = false,
+  placeholder = null,
+  disabled = null,
+}) => {
+  return (
+    <>
+      {type === "radio" || type === "checkbox" ? (
+        <div className="my-0">
+          <input
+            type={type}
+            name={name}
+            value={value}
+            className={className && `mr-2 ${className}`}
+            onChange={onChange}
+            checked={checked}
+            disabled={disabled}
+          />
+          <label htmlFor={id} className="font-medium ml-2">
+            {children}
+          </label>
+        </div>
+      ) : (
+        <div className="my-2">
+          <label htmlFor={id} className="font-demi">
+            {children}
+          </label>
+          <input
+            type={type}
+            name={name}
+            value={value}
+            className={
+              type === "file"
+                ? `ml-3 ${className}`
+                : `form-control ${className}`
+            }
+            onChange={onChange}
+            checked={checked}
+            placeholder={placeholder}
+          />
+        </div>
+      )}
+    </>
+  );
+};
+
+InputContainer.propTypes = {
+  type: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  id: PropTypes.string,
+  placeholder: PropTypes.string,
+  value: PropTypes.string,
+  className: PropTypes.string,
+  onChange: PropTypes.func,
+  checked: PropTypes.bool,
+  disabled: PropTypes.bool,
+  children: PropTypes.node,
+};
+
+export default InputContainer;

--- a/src/pages/Upload/ImportReport/index.js
+++ b/src/pages/Upload/ImportReport/index.js
@@ -1,0 +1,206 @@
+/*
+ Copyright (C) 2021 Shruti Agarwal (mail2shruti.ag@gmail.com)
+
+ SPDX-License-Identifier: GPL-2.0
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+import React, { useState } from "react";
+import InputContainer from "../../../components/Widgets/Input";
+import Button from "../../../components/Widgets/Button";
+
+const ImportReport = () => {
+  const initialState = {
+    folder: "",
+    editUpload: "",
+    reportUpload: "",
+    newLicense: "licenseCanditate",
+    licenseInfoInFile: true,
+    licenseConcluded: false,
+    licenseDecision: true,
+    existingDecisions: true,
+    importDiscussed: true,
+    copyright: false,
+  };
+  const [importReportData, setImportReportData] = useState(initialState);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+  };
+  const handleChange = (e) => {
+    if (e.target.type === "checkbox") {
+      setImportReportData({
+        ...importReportData,
+        [e.target.name]: e.target.checked,
+      });
+    } else {
+      setImportReportData({
+        ...importReportData,
+        [e.target.name]: e.target.value,
+      });
+    }
+  };
+  return (
+    <div className="main-container my-3">
+      <div className="row">
+        <div className="col-lg-8 col-md-10 col-sm-12 col-12">
+          <h3 className="font-size-sub-heading">Report Import</h3>
+          <form className="my-3">
+            <InputContainer
+              type="text"
+              value={importReportData.folder}
+              name="folder"
+              id="upload-report"
+              onChange={(e) => handleChange(e)}
+            >
+              Select the folder that contains the upload:
+            </InputContainer>
+            <InputContainer
+              type="text"
+              value={importReportData.editUpload}
+              name="editUpload"
+              id="upload-report"
+              onChange={(e) => handleChange(e)}
+            >
+              Select the upload you wish to edit:
+            </InputContainer>
+            <InputContainer
+              type="file"
+              value={importReportData.reportUpload}
+              name="reportUpload"
+              id="upload-report"
+              onChange={(e) => handleChange(e)}
+            >
+              Select report to upload:
+            </InputContainer>
+            <div className="font-medium">
+              Select how the information should be imported:
+              <ul>
+                <li className="mt-2">
+                  Create new licenses as:
+                  <ul>
+                    <li>
+                      <InputContainer
+                        type="radio"
+                        value="licenseCanditate"
+                        name="newLicense"
+                        id="upload-report-license-candidate"
+                        checked={
+                          importReportData.newLicense === "licenseCanditate"
+                        }
+                        onChange={(e) => handleChange(e)}
+                      >
+                        License candidate
+                      </InputContainer>
+                    </li>
+                    <li>
+                      <InputContainer
+                        type="radio"
+                        value="newLicense"
+                        name="newLicense"
+                        id="upload-report-new-license"
+                        checked={importReportData.newLicense === "newLicense"}
+                        onChange={(e) => handleChange(e)}
+                      >
+                        New License
+                      </InputContainer>
+                    </li>
+                  </ul>
+                </li>
+                <li className="mt-2">
+                  Add the License Info as findings from:
+                  <ul>
+                    <li>
+                      <InputContainer
+                        type="checkbox"
+                        checked={importReportData.licenseInfoInFile}
+                        name="licenseInfoInFile"
+                        id="upload-report-license-info-file"
+                        onChange={(e) => handleChange(e)}
+                      >
+                        SPDX tag of type licenseInfoInFile
+                      </InputContainer>
+                    </li>
+                    <li>
+                      <InputContainer
+                        type="checkbox"
+                        checked={importReportData.licenseConcluded}
+                        name="licenseConcluded"
+                        id="upload-report-license-concluded"
+                        onChange={(e) => handleChange(e)}
+                      >
+                        SPDX tag of type licenseConcluded
+                      </InputContainer>
+                    </li>
+                  </ul>
+                </li>
+                <li className="mt-2">
+                  <InputContainer
+                    type="checkbox"
+                    checked={importReportData.licenseDecision}
+                    name="licenseDecision"
+                    id="upload-report-license-decisions"
+                    onChange={(e) => handleChange(e)}
+                  >
+                    Add concluded licenses as decisions
+                  </InputContainer>
+                  <ul>
+                    <li>
+                      <InputContainer
+                        type="checkbox"
+                        checked={importReportData.existingDecisions}
+                        name="existingDecisions"
+                        id="upload-report-existing-decisions"
+                        onChange={(e) => handleChange(e)}
+                        disabled={true}
+                      >
+                        Also overwrite existing decisions
+                      </InputContainer>
+                    </li>
+                    <li>
+                      <InputContainer
+                        type="checkbox"
+                        checked={importReportData.importDiscussed}
+                        name="importDiscussed"
+                        id="upload-report-import-discussed"
+                        onChange={(e) => handleChange(e)}
+                      >
+                        Import as "to be discussed"
+                      </InputContainer>
+                    </li>
+                  </ul>
+                </li>
+                <li className="mt-2">
+                  <InputContainer
+                    type="checkbox"
+                    checked={importReportData.copyright}
+                    name="copyright"
+                    id="upload-report-existing-copyright"
+                    onChange={(e) => handleChange(e)}
+                  >
+                    Add the copyright information as textfindings
+                  </InputContainer>
+                </li>
+              </ul>
+            </div>
+            <Button type="submit" onClick={handleSubmit} className="mt-4">
+              Upload and Import
+            </Button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ImportReport;


### PR DESCRIPTION
## Description

Added the Import report page of uploads section.

### Changes

- Added the report Import page.
- Added Input widget which can be used with all the pages.

***Note: Added all the state variables for the page as soon as we get the api we have to just link them.***

## How to test
Visit to the route `/upload/report`

## Screenshots

![Screenshot from 2021-06-26 20-15-03](https://user-images.githubusercontent.com/56133783/123516741-3fa5f000-d6bb-11eb-99e1-5f30a0c10cbc.png)
