### PR TITLE
feat(upload): added the upload file page

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -40,6 +40,7 @@ import CreateFolder from "./pages/Organize/Folder/Create";
 
 // Routes imports
 import { routes } from "./constants/routes";
+import UploadFile from "./pages/Upload/File";
 
 const Routes = () => {
   return (
@@ -57,6 +58,7 @@ const Routes = () => {
           path={routes.upload.instructions}
           component={Instructions}
         />
+        <PrivateLayout exact path={routes.upload.file} component={UploadFile} />
         <PublicLayout exact path={routes.help.about} component={About} />
         <PublicLayout
           exact

--- a/src/api/getFolder.js
+++ b/src/api/getFolder.js
@@ -24,7 +24,7 @@ export const getAllFolders = () => {
   return sendRequest({
     url,
     method: "GET",
-    credentials: false,
+    credentials: "include",
     headers: {
       Authorization: getToken(),
     },

--- a/src/api/getFolder.js
+++ b/src/api/getFolder.js
@@ -1,4 +1,4 @@
-/***************************************************************
+/*
  Copyright (C) 2021 Shruti Agarwal (mail2shruti.ag@gmail.com)
 
  SPDX-License-Identifier: GPL-2.0
@@ -10,21 +10,23 @@
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
-
  You should have received a copy of the GNU General Public License along
  with this program; if not, write to the Free Software Foundation, Inc.,
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-***************************************************************/
+*/
 
-import React from "react";
-import CommonFields from "../../../components/Upload/CommonFields";
+import { endpoints } from "../constants/endpoints";
+import sendRequest from "./sendRequest";
+import { getToken } from "../shared/authHelper";
 
-const UploadFromServer = () => {
-  return (
-    <div className="main-container my-3">
-      <CommonFields />
-    </div>
-  );
+export const getAllFolders = () => {
+  const url = endpoints.folders.getAll();
+  return sendRequest({
+    url,
+    method: "GET",
+    credentials: false,
+    headers: {
+      Authorization: getToken(),
+    },
+  });
 };
-
-export default UploadFromServer;

--- a/src/api/upload.js
+++ b/src/api/upload.js
@@ -1,0 +1,122 @@
+/*
+ Copyright (C) 2021 Shruti Agarwal (mail2shruti.ag@gmail.com)
+
+ SPDX-License-Identifier: GPL-2.0
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+import sendRequest from "./sendRequest";
+import { endpoints } from "../constants/endpoints";
+import { getToken } from "../shared/helper";
+import PropTypes from "prop-types";
+
+export const createUpload = async (
+  folderId,
+  uploadDescription,
+  accessLevel,
+  ignoreScm,
+  fileInput
+) => {
+  const url = endpoints.upload.uploadCreate();
+  const token = await getToken();
+  var formdata = new FormData();
+  if (fileInput) {
+    formdata.append("fileInput", fileInput, fileInput?.name);
+  }
+  return sendRequest({
+    url,
+    method: "POST",
+    credentials: "include",
+    isMultipart: true,
+    headers: {
+      Authorization: token,
+      folderId,
+      uploadDescription,
+      accessLevel,
+      ignoreScm,
+      uploadType: "vcs",
+      groupName: "",
+    },
+    body: formdata,
+  });
+};
+
+export const scheduleAnalysis = async (folderId, uploadId, scanData) => {
+  const url = endpoints.upload.scheduleAnalysis();
+  const token = await getToken();
+  const { bucket, copyrightEmailAuthor, ecc, keyword, mime, monk, nomos, ojo } =
+    scanData?.analysis;
+  const { nomosMonk, bulkReused, newScanner, ojoDecider } = scanData?.decider;
+  const { reuseUpload, reuseGroup, reuseMain, reuseEnhanced } = scanData?.reuse;
+  return sendRequest({
+    url,
+    method: "POST",
+    credentials: "include",
+    headers: {
+      Authorization: token,
+      folderId,
+      uploadId,
+      groupName: "",
+    },
+    body: {
+      analysis: {
+        bucket,
+        copyright_email_author: copyrightEmailAuthor,
+        ecc,
+        keyword,
+        mime,
+        monk,
+        nomos,
+        ojo,
+        package: scanData.analysis.package,
+      },
+      decider: {
+        nomos_monk: nomosMonk,
+        bulk_reused: bulkReused,
+        new_scanner: newScanner,
+        ojo_decider: ojoDecider,
+      },
+      reuse: {
+        reuse_upload: reuseUpload,
+        reuse_group: reuseGroup,
+        reuse_main: reuseMain,
+        reuse_enhanced: reuseEnhanced,
+      },
+    },
+  });
+};
+
+export const getUploadById = async (uploadId) => {
+  const url = endpoints.upload.getId(uploadId);
+  const token = await getToken();
+  return sendRequest({
+    url,
+    method: "GET",
+    credentials: "include",
+    headers: {
+      Authorization: token,
+      uploadId,
+      groupName: "",
+    },
+  });
+};
+
+createUpload.propTypes = {
+  folderId: PropTypes.number,
+  uploadDescription: PropTypes.string,
+  accessLevel: PropTypes.string,
+  ignoreScm: PropTypes.bool,
+  fileInput: PropTypes.string,
+  groupName: PropTypes.string,
+};

--- a/src/api/upload.js
+++ b/src/api/upload.js
@@ -45,7 +45,7 @@ export const createUpload = async (
       uploadDescription,
       accessLevel,
       ignoreScm,
-      uploadType: "vcs",
+      uploadType: "",
       groupName: "",
     },
     body: formdata,

--- a/src/components/Upload/CommonFields/AccessLevel/index.js
+++ b/src/components/Upload/CommonFields/AccessLevel/index.js
@@ -1,0 +1,47 @@
+import React from "react";
+import PropTypes from "prop-types";
+import InputContainer from "../../../Widgets/Input";
+
+function AccessLevel({ accessLevel, handleChange }) {
+  return (
+    <div id="upload-access-level" className="mt-4">
+      <InputContainer
+        type="radio"
+        value="private"
+        name="accessLevel"
+        id="upload-report-license-candidate"
+        checked={accessLevel === "private"}
+        onChange={(e) => handleChange(e)}
+      >
+        Visible only for active group
+      </InputContainer>
+      <InputContainer
+        type="radio"
+        value="protected"
+        name="accessLevel"
+        id="upload-report-new-license"
+        checked={accessLevel === "protected"}
+        onChange={(e) => handleChange(e)}
+      >
+        Visible for all groups
+      </InputContainer>
+      <InputContainer
+        type="radio"
+        value="public"
+        name="accessLevel"
+        id="upload-report-new-license"
+        checked={accessLevel === "public"}
+        onChange={(e) => handleChange(e)}
+      >
+        Make Public
+      </InputContainer>
+    </div>
+  );
+}
+
+AccessLevel.propTypes = {
+  accessLevel: PropTypes.string.isRequired,
+  handleChange: PropTypes.func.isRequired,
+};
+
+export default AccessLevel;

--- a/src/components/Upload/CommonFields/IgnoreScm/index.js
+++ b/src/components/Upload/CommonFields/IgnoreScm/index.js
@@ -1,0 +1,26 @@
+import React from "react";
+import PropTypes from "prop-types";
+import InputContainer from "../../../Widgets/Input";
+
+function IgnoreScm({ ignoreScm, handleChange }) {
+  return (
+    <div id="upload-ignore-files" className="mt-4">
+      <InputContainer
+        type="checkbox"
+        checked={ignoreScm}
+        name="ignoreScm"
+        id="upload-report-license-concluded"
+        onChange={(e) => handleChange(e)}
+      >
+        Ignore SCM files (Git, SVN, TFS) and files with particular Mimetype
+      </InputContainer>
+    </div>
+  );
+}
+
+IgnoreScm.propTypes = {
+  ignoreScm: PropTypes.bool.isRequired,
+  handleChange: PropTypes.func,
+};
+
+export default IgnoreScm;

--- a/src/components/Upload/CommonFields/LicenseDecider/index.js
+++ b/src/components/Upload/CommonFields/LicenseDecider/index.js
@@ -1,0 +1,56 @@
+import React from "react";
+import PropTypes from "prop-types";
+import InputContainer from "../../../Widgets/Input";
+
+function LicenseDecider({ decider, handleChange }) {
+  return (
+    <div id="upload-concluded-license-decider" className="mt-4">
+      <p className="font-demi">Automatic Concluded License Decider, based on</p>
+      <InputContainer
+        type="checkbox"
+        checked={decider.nomosMonk}
+        name="nomosMonk"
+        id="upload-file-nomos-monk"
+        onChange={(e) => handleChange(e)}
+      >
+        ... scanners matches if all Nomos findings are within the Monk findings
+      </InputContainer>
+      <InputContainer
+        type="checkbox"
+        checked={decider.ojoDecider}
+        name="ojoDecider"
+        id="upload-file-ojo-decider"
+        onChange={(e) => handleChange(e)}
+      >
+        .. scanners matches if Ojo findings are no contradiction with other
+        findings
+      </InputContainer>
+      <InputContainer
+        type="checkbox"
+        checked={decider.bulkReused}
+        name="bulkReused"
+        id="upload-file-bulk-reused"
+        onChange={(e) => handleChange(e)}
+      >
+        ... bulk phrases from reused packages
+      </InputContainer>
+      <InputContainer
+        type="checkbox"
+        checked={decider.newScanner}
+        name="newScanner"
+        id="upload-file-new-scanner"
+        onChange={(e) => handleChange(e)}
+      >
+        ... new scanner results, i.e., decisions were marked as work in progress
+        if new scanner finds additional licenses
+      </InputContainer>
+    </div>
+  );
+}
+
+LicenseDecider.propTypes = {
+  decider: PropTypes.object,
+  handleChange: PropTypes.func,
+};
+
+export default LicenseDecider;

--- a/src/components/Upload/CommonFields/OptionalAnalysis/index.js
+++ b/src/components/Upload/CommonFields/OptionalAnalysis/index.js
@@ -1,0 +1,94 @@
+import React from "react";
+import PropTypes from "prop-types";
+import InputContainer from "../../../Widgets/Input";
+
+function OptionalAnalysis({ analysis, handleChange }) {
+  return (
+    <div id="uplod-optional-analysis" className="mt-4">
+      <p className="font-demi">Select optional analysis</p>
+      <InputContainer
+        type="checkbox"
+        checked={analysis.copyrightEmailAuthor}
+        name="copyrightEmailAuthor"
+        id="upload-file-copyright-email-author"
+        onChange={(e) => handleChange(e)}
+      >
+        Copyright/Email/URL/Author Analysis
+      </InputContainer>
+      <InputContainer
+        type="checkbox"
+        checked={analysis.ecc}
+        name="ecc"
+        id="upload-file-ecc"
+        onChange={(e) => handleChange(e)}
+      >
+        ECC Analysis, scanning for text fragments potentially relevant for
+        export control
+      </InputContainer>
+      <InputContainer
+        type="checkbox"
+        checked={analysis.keyword}
+        name="keyword"
+        id="upload-file-keyword"
+        onChange={(e) => handleChange(e)}
+      >
+        Keyword Analysis
+      </InputContainer>
+      <InputContainer
+        type="checkbox"
+        checked={analysis.mime}
+        name="mime"
+        id="upload-file-mime"
+        onChange={(e) => handleChange(e)}
+      >
+        MIME-type Analysis (Determine mimetype of every file. Not needed for
+        licenses or buckets)
+      </InputContainer>
+      <InputContainer
+        type="checkbox"
+        checked={analysis.monk}
+        name="monk"
+        id="upload-file-monk"
+        onChange={(e) => handleChange(e)}
+      >
+        Monk License Analysis, scanning for licenses performing a text
+        comparison
+      </InputContainer>
+      <InputContainer
+        type="checkbox"
+        checked={analysis.nomos}
+        name="nomos"
+        id="upload-file-nomos"
+        onChange={(e) => handleChange(e)}
+      >
+        Nomos License Analysis, scanning for licenses using regular expressions
+      </InputContainer>
+      <InputContainer
+        type="checkbox"
+        checked={analysis.ojo}
+        name="ojo"
+        id="upload-file-ojo"
+        onChange={(e) => handleChange(e)}
+      >
+        Ojo License Analysis, scanning for licenses using
+        SPDX-License-Identifier
+      </InputContainer>
+      <InputContainer
+        type="checkbox"
+        checked={analysis.package}
+        name="package"
+        id="upload-file-package"
+        onChange={(e) => handleChange(e)}
+      >
+        Package Analysis (Parse package headers)
+      </InputContainer>
+    </div>
+  );
+}
+
+OptionalAnalysis.propTypes = {
+  analysis: PropTypes.object,
+  handleChange: PropTypes.func,
+};
+
+export default OptionalAnalysis;

--- a/src/components/Upload/CommonFields/UploadReuse/index.js
+++ b/src/components/Upload/CommonFields/UploadReuse/index.js
@@ -6,18 +6,6 @@ function UploadReuse({ reuse, handleChange }) {
   return (
     <div id="upload-reuse" className="mt-4">
       <p className="font-demi">(Optional) Reuse</p>
-      {/* <InputContainer
-        type="checkbox"
-        checked={reuse.main}
-        name="licenseConcluded"
-        id="upload-file"
-        onChange={(e) => handleChange(e)}
-      >
-        Select an already uploaded package for reuse in specific folder
-      </InputContainer>
-      <select>
-        <option value="Software Repository">Software Repository</option>
-      </select> */}
       <InputContainer
         type="checkbox"
         checked={reuse.reuseEnhanced}
@@ -36,24 +24,6 @@ function UploadReuse({ reuse, handleChange }) {
       >
         Reuse main license/s
       </InputContainer>
-      {/* <InputContainer
-        type="checkbox"
-        checked={reuse.main}
-        name="licenseConcluded"
-        id="upload-file"
-        onChange={(e) => handleChange(e)}
-      >
-        Reuse report configuration settings
-      </InputContainer>
-      <InputContainer
-        type="checkbox"
-        checked={reuse.main}
-        name="licenseConcluded"
-        id="upload-file"
-        onChange={(e) => handleChange(e)}
-      >
-        Reuse deactivated copyright when agent version changes
-      </InputContainer> */}
     </div>
   );
 }

--- a/src/components/Upload/CommonFields/UploadReuse/index.js
+++ b/src/components/Upload/CommonFields/UploadReuse/index.js
@@ -1,0 +1,66 @@
+import React from "react";
+import PropTypes from "prop-types";
+import InputContainer from "../../../Widgets/Input";
+
+function UploadReuse({ reuse, handleChange }) {
+  return (
+    <div id="upload-reuse" className="mt-4">
+      <p className="font-demi">(Optional) Reuse</p>
+      {/* <InputContainer
+        type="checkbox"
+        checked={reuse.main}
+        name="licenseConcluded"
+        id="upload-file"
+        onChange={(e) => handleChange(e)}
+      >
+        Select an already uploaded package for reuse in specific folder
+      </InputContainer>
+      <select>
+        <option value="Software Repository">Software Repository</option>
+      </select> */}
+      <InputContainer
+        type="checkbox"
+        checked={reuse.reuseEnhanced}
+        name="reuseEnhanced"
+        id="upload-file-reuse-enhanced"
+        onChange={(e) => handleChange(e)}
+      >
+        Enhanced reuse (slower)
+      </InputContainer>
+      <InputContainer
+        type="checkbox"
+        checked={reuse.reuseMain}
+        name="reuseMain"
+        id="upload-file-reuse-main"
+        onChange={(e) => handleChange(e)}
+      >
+        Reuse main license/s
+      </InputContainer>
+      {/* <InputContainer
+        type="checkbox"
+        checked={reuse.main}
+        name="licenseConcluded"
+        id="upload-file"
+        onChange={(e) => handleChange(e)}
+      >
+        Reuse report configuration settings
+      </InputContainer>
+      <InputContainer
+        type="checkbox"
+        checked={reuse.main}
+        name="licenseConcluded"
+        id="upload-file"
+        onChange={(e) => handleChange(e)}
+      >
+        Reuse deactivated copyright when agent version changes
+      </InputContainer> */}
+    </div>
+  );
+}
+
+UploadReuse.propTypes = {
+  reuse: PropTypes.object,
+  handleChange: PropTypes.func,
+};
+
+export default UploadReuse;

--- a/src/components/Upload/CommonFields/index.js
+++ b/src/components/Upload/CommonFields/index.js
@@ -1,0 +1,57 @@
+/*
+ Copyright (C) 2021 Shruti Agarwal (mail2shruti.ag@gmail.com)
+
+ SPDX-License-Identifier: GPL-2.0
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+import React from "react";
+import PropTypes from "prop-types";
+import IgnoreScm from "./IgnoreScm";
+import AccessLevel from "./AccessLevel";
+import OptionalAnalysis from "./OptionalAnalysis";
+import LicenseDecider from "./LicenseDecider";
+import UploadReuse from "./UploadReuse";
+
+function CommonFields({
+  accessLevel,
+  ignoreScm,
+  analysis,
+  decider,
+  reuse,
+  handleChange,
+  handleScanChange,
+}) {
+  return (
+    <>
+      <IgnoreScm ignoreScm={ignoreScm} handleChange={handleChange} />
+      <AccessLevel accessLevel={accessLevel} handleChange={handleChange} />
+      <OptionalAnalysis analysis={analysis} handleChange={handleScanChange} />
+      <LicenseDecider decider={decider} handleChange={handleScanChange} />
+      <UploadReuse reuse={reuse} handleChange={handleScanChange} />
+    </>
+  );
+}
+
+CommonFields.propTypes = {
+  accessLevel: PropTypes.string,
+  ignoreScm: PropTypes.bool,
+  analysis: PropTypes.object,
+  decider: PropTypes.object,
+  reuse: PropTypes.object,
+  handleChange: PropTypes.func,
+  handleScanChange: PropTypes.func,
+};
+
+export default CommonFields;

--- a/src/components/Widgets/Input/index.js
+++ b/src/components/Widgets/Input/index.js
@@ -30,6 +30,8 @@ const InputContainer = ({
   placeholder = null,
   disabled = null,
   options = null,
+  multiple = null,
+  property,
 }) => {
   if (type === "radio" || type === "checkbox") {
     return (
@@ -60,13 +62,20 @@ const InputContainer = ({
           className={className && `mr-2 ${className}`}
           value={value}
           onChange={onChange}
+          multiple={multiple && multiple}
+          size={multiple && "15"}
         >
-          {options.map((option, index) => (
-            <option key={option.id || index} value={option.id}>
-              {" "}
-              {option.name}{" "}
+          {options.length > 0 ? (
+            options.map((option, index) => (
+              <option key={option.id || index} value={option.id}>
+                {option[property]}
+              </option>
+            ))
+          ) : (
+            <option className="font-demi" disabled={true}>
+              No Data Found
             </option>
-          ))}
+          )}
         </select>
       </div>
     );
@@ -96,13 +105,15 @@ InputContainer.propTypes = {
   name: PropTypes.string.isRequired,
   id: PropTypes.string,
   placeholder: PropTypes.string,
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  value: PropTypes.node,
   className: PropTypes.string,
   onChange: PropTypes.func,
   checked: PropTypes.bool,
   disabled: PropTypes.bool,
   children: PropTypes.node,
   options: PropTypes.array,
+  multiple: PropTypes.string,
+  property: PropTypes.string,
 };
 
 export default InputContainer;

--- a/src/constants/endpoints.js
+++ b/src/constants/endpoints.js
@@ -36,4 +36,9 @@ export const endpoints = {
     create: () => `${apiUrl}/folders`,
     delete: (folderId) => `${apiUrl}/folders/${folderId}`,
   },
+  upload: {
+    uploadCreate: () => `${apiUrl}/uploads`,
+    scheduleAnalysis: () => `${apiUrl}/jobs`,
+    getId: (uploadId) => `${apiUrl}/uploads/${uploadId}`,
+  },
 };

--- a/src/pages/Search/index.js
+++ b/src/pages/Search/index.js
@@ -46,7 +46,7 @@ const Search = () => {
   return (
     <div className="main-container my-3">
       <div className="row">
-        <div className="col-lg-8 col-md-12 col-sm-12 col-12 bg-white home-box-shadow">
+        <div className="col-lg-8 col-md-12 col-sm-12 col-12">
           <form>
             <InputContainer
               value="directory"
@@ -169,7 +169,7 @@ const Search = () => {
               </h3>
               {searchResult.map(
                 ({ uploadName, folderName, fileName }, index) => (
-                  <div key={index} className="card p-3 mt-2">
+                  <div key={index} className="box p-3 mt-2">
                     <div className="font-demi">
                       {index + 1}. Folder: {folderName}
                     </div>

--- a/src/pages/Upload/File/index.js
+++ b/src/pages/Upload/File/index.js
@@ -84,8 +84,8 @@ const UploadFile = () => {
           type: "success",
           text: "Successfully uploaded the files",
         });
-        uploadId = res.message;
         scrollTo({ top: 0 });
+        uploadId = res.message;
       })
       .then(() => {
         setTimeout(
@@ -97,6 +97,8 @@ const UploadFile = () => {
                   text: "Analysis for the file is scheduled.",
                 });
                 scrollTo({ top: 0 });
+                setUploadFileData(initialState);
+                setScanFileData(initialScanFileData);
               })
               .catch((error) => {
                 setMessage({
@@ -105,7 +107,7 @@ const UploadFile = () => {
                 });
                 scrollTo({ top: 0 });
               }),
-          1000
+          1200
         );
       })
       .catch((error) => {

--- a/src/pages/Upload/File/index.js
+++ b/src/pages/Upload/File/index.js
@@ -1,6 +1,6 @@
-/***************************************************************
+/*
  Copyright (C) 2021 Shruti Agarwal (mail2shruti.ag@gmail.com)
- 
+
  SPDX-License-Identifier: GPL-2.0
 
  This program is free software; you can redistribute it and/or
@@ -14,12 +14,254 @@
  You should have received a copy of the GNU General Public License along
  with this program; if not, write to the Free Software Foundation, Inc.,
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-***************************************************************/
+*/
 
-import React from "react";
+import React, { useState, useEffect } from "react";
+import InputContainer from "../../../components/Widgets/Input";
+import Button from "../../../components/Widgets/Button";
+import CommonFields from "../../../components/Upload/CommonFields";
+import { createUploadFile, scheduleJobs } from "../../../services/upload";
+import { getFolders } from "../../../services/getFolder";
+import { Spinner, Alert } from "react-bootstrap";
 
 const UploadFile = () => {
-  return <div>UploadFile</div>;
+  const initialState = {
+    folderId: 1,
+    uploadDescription: "",
+    accessLevel: "protected",
+    ignoreScm: false,
+    fileInput: null,
+  };
+  const initialScanFileData = {
+    analysis: {
+      bucket: true,
+      copyrightEmailAuthor: false,
+      ecc: false,
+      keyword: false,
+      mime: false,
+      monk: false,
+      nomos: false,
+      ojo: false,
+      package: false,
+    },
+    decider: {
+      nomosMonk: false,
+      bulkReused: false,
+      newScanner: false,
+      ojoDecider: false,
+    },
+    reuse: {
+      reuseUpload: 0,
+      reuseGroup: "",
+      reuseMain: false,
+      reuseEnhanced: false,
+    },
+  };
+  const initialFolderList = [
+    {
+      id: 1,
+      name: "Software Repository",
+      description: "Top Folder",
+      parent: null,
+    },
+  ];
+
+  let uploadId;
+
+  const [uploadFileData, setUploadFileData] = useState(initialState);
+  const [folderList, setFolderList] = useState(initialFolderList);
+  const [scanFileData, setScanFileData] = useState(initialScanFileData);
+  const [loading, setLoading] = useState(false);
+  const [showMessage, setShowMessage] = useState(false);
+  const [message, setMessage] = useState();
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    setLoading(true);
+    createUploadFile(uploadFileData)
+      .then((res) => {
+        setMessage({
+          type: "success",
+          text: "Successfully uploaded the files",
+        });
+        uploadId = res.message;
+        scrollTo({ top: 0 });
+      })
+      .then(() => {
+        setTimeout(
+          () =>
+            scheduleJobs(uploadFileData.folderId, uploadId, scanFileData)
+              .then(() => {
+                setMessage({
+                  type: "success",
+                  text: "Analysis for the file is scheduled.",
+                });
+                scrollTo({ top: 0 });
+              })
+              .catch((error) => {
+                setMessage({
+                  type: "danger",
+                  text: error.message,
+                });
+                scrollTo({ top: 0 });
+              }),
+          1000
+        );
+      })
+      .catch((error) => {
+        setMessage({
+          type: "danger",
+          text: error.message,
+        });
+        scrollTo({ top: 0 });
+      })
+      .finally(() => {
+        setLoading(false);
+        setShowMessage(true);
+      });
+  };
+  const handleChange = (e) => {
+    if (e.target.type === "checkbox") {
+      setUploadFileData({
+        ...uploadFileData,
+        [e.target.name]: e.target.checked,
+      });
+    } else if (e.target.type === "file") {
+      setUploadFileData({
+        ...uploadFileData,
+        [e.target.name]: e.target.files[0],
+      });
+    } else {
+      setUploadFileData({
+        ...uploadFileData,
+        [e.target.name]: e.target.value,
+      });
+    }
+  };
+  const handleScanChange = (e) => {
+    const name = e.target.name;
+    if (
+      Object.keys(scanFileData.analysis).find((analysis) => analysis === name)
+    ) {
+      setScanFileData({
+        ...scanFileData,
+        analysis: {
+          ...scanFileData.analysis,
+          [e.target.name]: e.target.checked,
+        },
+      });
+    } else if (
+      Object.keys(scanFileData.decider).find((decider) => decider === name)
+    ) {
+      setScanFileData({
+        ...scanFileData,
+        decider: {
+          ...scanFileData.decider,
+          [e.target.name]: e.target.checked,
+        },
+      });
+    } else {
+      setScanFileData({
+        ...scanFileData,
+        reuse: {
+          ...scanFileData.reuse,
+          [e.target.name]: e.target.checked,
+        },
+      });
+    }
+  };
+  useEffect(() => {
+    getFolders().then((res) => {
+      setFolderList(res);
+    });
+  }, []);
+  return (
+    <>
+      {showMessage && (
+        <Alert
+          variant={message.type}
+          onClose={() => setShowMessage(false)}
+          dismissible
+        >
+          <p>{message.text}</p>
+        </Alert>
+      )}
+      <div className="main-container my-3">
+        <div className="row">
+          <div className="col-lg-8 col-md-12 col-sm-12 col-12">
+            <h3 className="font-size-sub-heading">Upload a New file</h3>
+            <p className="font-demi my-3">
+              To manage your own group permissions go into Admin &gt; Groups
+              &gt; Manage Group Users. To manage permissions for this one
+              upload, go to Admin &gt; Upload Permissions.
+            </p>
+            <p>
+              This option permits uploading a single file (which may be iso,
+              tar, rpm, jar, zip, bz2, msi, cab, etc.) from your computer to
+              FOSSology. Your FOSSology server has imposed a maximum upload file
+              size of 700Mbytes.
+            </p>
+            <form className="my-3">
+              <InputContainer
+                type="select"
+                name="folderId"
+                id="upload-folder-id"
+                onChange={(e) => handleChange(e)}
+                options={folderList}
+                property="name"
+                value={folderList?.id}
+              >
+                Select the folder for storing the uploaded files:
+              </InputContainer>
+              <InputContainer
+                type="file"
+                name="fileInput"
+                id="upload-file-input"
+                onChange={(e) => handleChange(e)}
+              >
+                Select file to upload:
+              </InputContainer>
+              <div className="my-2">
+                <label htmlFor="upload" className="font-demi font-15">
+                  (Optional) Enter a description of this file:
+                </label>
+                <textarea
+                  name="uploadDescription"
+                  className="form-control"
+                  value={uploadFileData.uploadDescription}
+                  id="upload-file-description"
+                  rows="3"
+                  onChange={(e) => handleChange(e)}
+                ></textarea>
+              </div>
+              <CommonFields
+                accessLevel={uploadFileData.accessLevel}
+                ignoreScm={uploadFileData.ignoreScm}
+                analysis={scanFileData.analysis}
+                decider={scanFileData.decider}
+                reuse={scanFileData.reuse}
+                handleChange={handleChange}
+                handleScanChange={handleScanChange}
+              />
+              <Button type="submit" onClick={handleSubmit} className="mt-4">
+                {loading ? (
+                  <Spinner
+                    as="span"
+                    animation="border"
+                    size="sm"
+                    role="status"
+                    aria-hidden="true"
+                  />
+                ) : (
+                  "Upload"
+                )}
+              </Button>
+            </form>
+          </div>
+        </div>
+      </div>
+    </>
+  );
 };
 
 export default UploadFile;

--- a/src/pages/Upload/Url/index.js
+++ b/src/pages/Upload/Url/index.js
@@ -19,7 +19,7 @@
 import React from "react";
 import CommonFields from "../../../components/Upload/CommonFields";
 
-const UploadFromServer = () => {
+const UploadFromUrl = () => {
   return (
     <div className="main-container my-3">
       <CommonFields />
@@ -27,4 +27,4 @@ const UploadFromServer = () => {
   );
 };
 
-export default UploadFromServer;
+export default UploadFromUrl;

--- a/src/pages/Upload/Vcs/index.js
+++ b/src/pages/Upload/Vcs/index.js
@@ -19,7 +19,7 @@
 import React from "react";
 import CommonFields from "../../../components/Upload/CommonFields";
 
-const UploadFromServer = () => {
+const UploadFromVcs = () => {
   return (
     <div className="main-container my-3">
       <CommonFields />
@@ -27,4 +27,4 @@ const UploadFromServer = () => {
   );
 };
 
-export default UploadFromServer;
+export default UploadFromVcs;

--- a/src/services/getFolder.js
+++ b/src/services/getFolder.js
@@ -1,8 +1,7 @@
-/***************************************************************
+/*
  Copyright (C) 2021 Shruti Agarwal (mail2shruti.ag@gmail.com)
 
  SPDX-License-Identifier: GPL-2.0
-
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
  version 2 as published by the Free Software Foundation.
@@ -10,21 +9,15 @@
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
-
  You should have received a copy of the GNU General Public License along
  with this program; if not, write to the Free Software Foundation, Inc.,
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-***************************************************************/
+*/
 
-import React from "react";
-import CommonFields from "../../../components/Upload/CommonFields";
+import { getAllFolders } from "../api/getFolder";
 
-const UploadFromServer = () => {
-  return (
-    <div className="main-container my-3">
-      <CommonFields />
-    </div>
-  );
-};
-
-export default UploadFromServer;
+export function getFolders() {
+  return getAllFolders().then((res) => {
+    return res;
+  });
+}

--- a/src/services/upload.js
+++ b/src/services/upload.js
@@ -1,4 +1,4 @@
-/***************************************************************
+/*
  Copyright (C) 2021 Shruti Agarwal (mail2shruti.ag@gmail.com)
 
  SPDX-License-Identifier: GPL-2.0
@@ -14,17 +14,36 @@
  You should have received a copy of the GNU General Public License along
  with this program; if not, write to the Free Software Foundation, Inc.,
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-***************************************************************/
+*/
 
-import React from "react";
-import CommonFields from "../../../components/Upload/CommonFields";
+import { createUpload, scheduleAnalysis, getUploadById } from "../api/upload";
 
-const UploadFromServer = () => {
-  return (
-    <div className="main-container my-3">
-      <CommonFields />
-    </div>
-  );
-};
+export function createUploadFile({
+  folderId,
+  uploadDescription,
+  accessLevel,
+  ignoreScm,
+  fileInput,
+}) {
+  return createUpload(
+    folderId,
+    uploadDescription,
+    accessLevel,
+    ignoreScm,
+    fileInput
+  ).then((res) => {
+    return res;
+  });
+}
 
-export default UploadFromServer;
+export function scheduleJobs(folderId, uploadId, scanData) {
+  return scheduleAnalysis(folderId, uploadId, scanData).then((res) => {
+    return res;
+  });
+}
+
+export function getId(uploadId) {
+  return getUploadById(uploadId).then((res) => {
+    return res;
+  });
+}

--- a/src/shared/helper.js
+++ b/src/shared/helper.js
@@ -1,8 +1,6 @@
 /*
  Copyright (C) 2021 Aman Dwivedi (aman.dwivedi5@gmail.com), Shruti Agarwal (mail2shruti.ag@gmail.com)
-
  SPDX-License-Identifier: GPL-2.0
-
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
  version 2 as published by the Free Software Foundation.
@@ -10,7 +8,6 @@
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
-
  You should have received a copy of the GNU General Public License along
  with this program; if not, write to the Free Software Foundation, Inc.,
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.


### PR DESCRIPTION
## Description

Added the upload file page.

## Changes

- Created the separate folder for uploads in Components that contains helper functions which will get reused in VCS, Url and server.
     - AccessLevel
     - Ignore Scm
     - License Decider
     - Optional Analysis
     - Upload Reuse
- Added the Upload file page

## How to test

visit to the route '/upload/file'

## Screenshots

![Screenshot from 2021-06-28 16-01-46](https://user-images.githubusercontent.com/56133783/123625178-1f963e00-d82d-11eb-8248-677a3e035b3c.png)
![Screenshot from 2021-06-28 16-24-01](https://user-images.githubusercontent.com/56133783/123625332-49e7fb80-d82d-11eb-8615-a0e8e74e3deb.png)
![Screenshot from 2021-06-29 16-51-41](https://user-images.githubusercontent.com/56133783/123789262-9cdbb480-d8fa-11eb-86c8-7239d67a139c.png)
![Screenshot from 2021-06-29 16-51-58](https://user-images.githubusercontent.com/56133783/123789269-9ea57800-d8fa-11eb-8467-e37771df51e8.png)
![Screenshot from 2021-06-29 16-52-05](https://user-images.githubusercontent.com/56133783/123789272-9fd6a500-d8fa-11eb-983a-8866db231943.png)
