### PR TITLE
feat(upload): added the delete uploads page

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -56,6 +56,7 @@ import MoveFolder from "./pages/Organize/Folder/Move";
 import AdviceLicenses from "./pages/Organize/License";
 import UploadEdit from "./pages/Organize/Uploads/Edit";
 import UploadMove from "./pages/Organize/Uploads/Move";
+import UploadDelete from "./pages/Organize/Uploads/Delete";
 
 // Default Page
 import ErrorPage from "./pages/ErrorPage";
@@ -170,6 +171,11 @@ const Routes = () => {
           exact
           path={routes.organize.uploads.move}
           component={UploadMove}
+        />
+        <PrivateLayout
+          exact
+          path={routes.organize.uploads.delete}
+          component={UploadDelete}
         />
 
         {/* Default Page */}

--- a/src/api/organizeUploads.js
+++ b/src/api/organizeUploads.js
@@ -18,11 +18,23 @@ import { endpoints } from "../constants/endpoints";
 import sendRequest from "./sendRequest";
 import { getToken } from "../shared/authHelper";
 
-export const getAllFolders = () => {
-  const url = endpoints.folders.getAll();
+export const getUploadsByFolderId = (id) => {
+  const url = endpoints.organize.uploads.get(id);
   return sendRequest({
     url,
     method: "GET",
+    credentials: "include",
+    headers: {
+      Authorization: getToken(),
+    },
+  });
+};
+
+export const deleteUploadsApi = (id) => {
+  const url = endpoints.organize.uploads.delete(id);
+  return sendRequest({
+    url,
+    method: "DELETE",
     credentials: "include",
     headers: {
       Authorization: getToken(),

--- a/src/constants/endpoints.js
+++ b/src/constants/endpoints.js
@@ -49,4 +49,10 @@ export const endpoints = {
     get: (folderId, recursive) =>
       `${apiUrl}/uploads?folderId=${folderId}&recursive=${recursive}`,
   },
+  organize: {
+    uploads: {
+      get: (folder) => `${apiUrl}/uploads?folderId=${folder}`,
+      delete: (deleteId) => `${apiUrl}/uploads/${deleteId}`,
+    },
+  },
 };

--- a/src/pages/Organize/Uploads/Delete/index.js
+++ b/src/pages/Organize/Uploads/Delete/index.js
@@ -16,10 +16,173 @@
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 ***************************************************************/
 
-import React from "react";
+import React, { useState, useEffect } from "react";
+import { Spinner, Alert } from "react-bootstrap";
+import InputContainer from "../../../../components/Widgets/Input";
+import Button from "../../../../components/Widgets/Button";
+import { getFolders } from "../../../../services/getFolder";
+import {
+  getUploadsFolderId,
+  deleteUploadsbyId,
+} from "../../../../services/organizeUploads";
 
-const UploadDeleteFolder = () => {
-  return <div>Upload Delete Folder</div>;
+const UploadDelete = () => {
+  const initialState = {
+    folderId: 1,
+    uploadId: null,
+    groupName: "",
+  };
+  const initialFolderList = [
+    {
+      id: 1,
+      name: "Software Repository",
+      description: "Top Folder",
+      parent: null,
+    },
+  ];
+  const initialMessage = {
+    type: "success",
+    text: "",
+  };
+  const [deleteUploadFolderData, setDeleteUploadFolderData] =
+    useState(initialState);
+  const [folderList, setFolderList] = useState(initialFolderList);
+  const [uploadFolderList, setUploadFolderList] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [showMessage, setShowMessage] = useState(false);
+  const [message, setMessage] = useState(initialMessage);
+
+  const handleChange = (e) => {
+    if (e.target.multiple) {
+      return setDeleteUploadFolderData({
+        ...deleteUploadFolderData,
+        [e.target.name]: Array.from(
+          e.target.selectedOptions,
+          (option) => option.value
+        ),
+      });
+    }
+    setDeleteUploadFolderData({
+      ...deleteUploadFolderData,
+      [e.target.name]: e.target.value,
+    });
+  };
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    setLoading(true);
+    deleteUploadFolderData.uploadId.length > 0 &&
+      deleteUploadFolderData?.uploadId?.map((id) => {
+        deleteUploadsbyId(parseInt(id))
+          .then(() => {
+            setMessage({
+              type: "success",
+              text: "Successfully scheduled selected uploads for deletion.",
+            });
+            getUploadsFolderId(deleteUploadFolderData.folderId).then((res) => {
+              setUploadFolderList(res);
+            });
+          })
+          .catch((error) => {
+            setMessage({
+              type: "danger",
+              text: error.message,
+            });
+          })
+          .finally(() => {
+            setLoading(false);
+            setShowMessage(true);
+          });
+      });
+  };
+
+  useEffect(() => {
+    getFolders().then((res) => {
+      setFolderList(res);
+    });
+    getUploadsFolderId(deleteUploadFolderData.folderId).then((res) => {
+      setUploadFolderList(res);
+    });
+  }, [deleteUploadFolderData.folderId, deleteUploadFolderData.uploadId]);
+
+  return (
+    <>
+      {showMessage && (
+        <Alert
+          variant={message.type}
+          onClose={() => setShowMessage(false)}
+          dismissible
+        >
+          <p>{message.text}</p>
+        </Alert>
+      )}
+      <div className="main-container my-3">
+        <h1 className="font-size-main-heading mb-4">Delete Uploaded File</h1>
+        <div className="row">
+          <div className="col-lg-8 col-md-12 col-sm-12 col-12">
+            <p>Select the uploaded file to delete</p>
+            <ul>
+              <li>This will delete the upload file!</li>
+              <li>
+                Be very careful with your selection since you can delete a lot
+                of work!
+              </li>
+              <li>
+                All analysis only associated with the deleted upload file will
+                also be deleted.
+              </li>
+              <li>
+                THERE IS NO UNDELETE. When you select something to delete, it
+                will be removed from the database and file repository.
+              </li>
+            </ul>
+            <p>Select the uploaded file to delete:</p>
+            <ul>
+              <li>
+                <InputContainer
+                  type="select"
+                  name="folderId"
+                  id="organize-upload-folder-list"
+                  onChange={(e) => handleChange(e)}
+                  options={folderList}
+                  property="name"
+                  value={folderList?.id}
+                >
+                  Select the folder containing the file to delete:
+                </InputContainer>
+              </li>
+              <li className="mt-4">
+                <InputContainer
+                  type="select"
+                  name="uploadId"
+                  id="organize-upload-list"
+                  onChange={(e) => handleChange(e)}
+                  options={uploadFolderList}
+                  value={uploadFolderList.id}
+                  property="uploadname"
+                  multiple="multiple"
+                >
+                  Select the uploaded project to delete:
+                </InputContainer>
+              </li>
+            </ul>
+            <Button type="submit" onClick={handleSubmit} className="mt-4">
+              {loading ? (
+                <Spinner
+                  as="span"
+                  animation="border"
+                  size="sm"
+                  role="status"
+                  aria-hidden="true"
+                />
+              ) : (
+                "Delete"
+              )}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
 };
 
-export default UploadDeleteFolder;
+export default UploadDelete;

--- a/src/services/organizeUploads.js
+++ b/src/services/organizeUploads.js
@@ -14,18 +14,16 @@
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-import { endpoints } from "../constants/endpoints";
-import sendRequest from "./sendRequest";
-import { getToken } from "../shared/authHelper";
+import { getUploadsByFolderId, deleteUploadsApi } from "../api/organizeUploads";
 
-export const getAllFolders = () => {
-  const url = endpoints.folders.getAll();
-  return sendRequest({
-    url,
-    method: "GET",
-    credentials: "include",
-    headers: {
-      Authorization: getToken(),
-    },
+export function getUploadsFolderId(folderId) {
+  return getUploadsByFolderId(folderId).then((res) => {
+    return res;
   });
-};
+}
+
+export function deleteUploadsbyId(deleteId) {
+  return deleteUploadsApi(deleteId).then((res) => {
+    return res;
+  });
+}


### PR DESCRIPTION
## Description

Added the delete Upload file page.

### Changes

- Created the getFolders page from where it is fetching all the folders.
- Created the organizeUploads which contains `deleteUploadFile` and `getUploadsById`.
- Added the property for options in InputContainer.

## How to test

Visit to `/organize/uploads/delete`

## Screenshots
![Screenshot from 2021-06-29 08-29-00](https://user-images.githubusercontent.com/56133783/123732399-7c3e3b00-d8b7-11eb-9351-c63c80be788f.png)
![Screenshot from 2021-06-29 08-41-18](https://user-images.githubusercontent.com/56133783/123732402-7e07fe80-d8b7-11eb-97bf-36193ade108e.png)
![Screenshot from 2021-06-29 08-42-13](https://user-images.githubusercontent.com/56133783/123732404-7ea09500-d8b7-11eb-919a-cd6d723197d1.png)
