### PR TITLE
feat(moveUpload): Added the move upload or copy upload page

### DIFF
--- a/src/api/organizeUploads.js
+++ b/src/api/organizeUploads.js
@@ -41,3 +41,31 @@ export const deleteUploadsApi = (id) => {
     },
   });
 };
+
+export const moveUploadApi = (folderId, id, groupName) => {
+  const url = endpoints.organize.uploads.move(id);
+  return sendRequest({
+    url,
+    method: "PATCH",
+    credentials: "include",
+    headers: {
+      Authorization: getToken(),
+      folderId,
+      groupName,
+    },
+  });
+};
+
+export const copyUploadApi = (folderId, id, groupName) => {
+  const url = endpoints.organize.uploads.copy(id);
+  return sendRequest({
+    url,
+    method: "PUT",
+    credentials: "include",
+    headers: {
+      Authorization: getToken(),
+      folderId,
+      groupName,
+    },
+  });
+};

--- a/src/components/Widgets/Input/index.js
+++ b/src/components/Widgets/Input/index.js
@@ -117,7 +117,7 @@ InputContainer.propTypes = {
   disabled: PropTypes.bool,
   children: PropTypes.node,
   options: PropTypes.array,
-  multiple: PropTypes.string,
+  multiple: PropTypes.bool,
   property: PropTypes.string,
 };
 

--- a/src/constants/endpoints.js
+++ b/src/constants/endpoints.js
@@ -53,6 +53,8 @@ export const endpoints = {
     uploads: {
       get: (folder) => `${apiUrl}/uploads?folderId=${folder}`,
       delete: (deleteId) => `${apiUrl}/uploads/${deleteId}`,
+      move: (moveId) => `${apiUrl}/uploads/${moveId}?recursive=false`,
+      copy: (copyId) => `${apiUrl}/uploads/${copyId}?recursive=false`,
     },
   },
 };

--- a/src/pages/Organize/Uploads/Move/index.js
+++ b/src/pages/Organize/Uploads/Move/index.js
@@ -1,4 +1,4 @@
-/***************************************************************
+/*
  Copyright (C) 2021 Shruti Agarwal (mail2shruti.ag@gmail.com)
 
  SPDX-License-Identifier: GPL-2.0
@@ -14,20 +14,196 @@
  You should have received a copy of the GNU General Public License along
  with this program; if not, write to the Free Software Foundation, Inc.,
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-***************************************************************/
+*/
 
-import React from "react";
+import React, { useState, useEffect } from "react";
+import InputContainer from "../../../../components/Widgets/Input";
+import Button from "../../../../components/Widgets/Button";
+import Alert from "../../../../components/Widgets/Alert";
+import { moveUpload, copyUpload } from "../../../../services/organizeUploads";
+import { getUploadsFolderId } from "../../../../services/organizeUploads";
+import { getFolders } from "../../../../services/getFolder";
 
 const UploadMove = () => {
+  const initialState = {
+    folderId: 1,
+    groupName: "",
+  };
+  const initialFolderList = [
+    {
+      id: 1,
+      name: "Software Repository",
+      description: "Top Folder",
+      parent: null,
+    },
+  ];
+  const initialMessage = {
+    type: "success",
+    text: "",
+  };
+  const [moveCopyUploadData, setMoveCopyUploadData] = useState(initialState);
+  const [moveCopyUploadsList, setMoveCopyUploadsList] = useState([]);
+  const [folderId, setFolderId] = useState(1);
+  const [folderList, setFolderList] = useState(initialFolderList);
+  const [uploadList, setUploadList] = useState([]);
+  const [showMessage, setShowMessage] = useState(false);
+  const [message, setMessage] = useState(initialMessage);
+
+  const handleChange = (e) => {
+    if (e.target.multiple) {
+      return setMoveCopyUploadsList(
+        Array.from(e.target.selectedOptions, (option) => option.value)
+      );
+    }
+    setMoveCopyUploadData({
+      ...moveCopyUploadData,
+      [e.target.name]: e.target.value,
+    });
+  };
+
+  const getUploadList = () => {
+    getUploadsFolderId(parseInt(folderId))
+      .then((res) => {
+        setUploadList(res);
+      })
+      .catch((error) => {
+        setMessage({
+          type: "danger",
+          text: error.message,
+        });
+        setShowMessage(true);
+      });
+  };
+  const handleMove = (e) => {
+    e.preventDefault();
+    moveCopyUploadsList.length > 0 &&
+      moveCopyUploadsList.map((id) => {
+        moveUpload(
+          moveCopyUploadData.folderId,
+          parseInt(id),
+          moveCopyUploadData.groupName
+        )
+          .then(() => {
+            setMessage({
+              type: "success",
+              text: "Successfully scheduled the selected uploads movement.",
+            });
+            getUploadList();
+          })
+          .catch((error) => {
+            setMessage({
+              type: "danger",
+              text: error.message,
+            });
+          })
+          .finally(() => {
+            setShowMessage(true);
+          });
+      });
+  };
+
+  const handleCopy = (e) => {
+    e.preventDefault();
+    moveCopyUploadsList.length > 0 &&
+      moveCopyUploadsList.map((id) => {
+        copyUpload(
+          moveCopyUploadData.folderId,
+          id,
+          moveCopyUploadData.groupName
+        )
+          .then(() => {
+            setMessage({
+              type: "success",
+              text: "Successfully scheduled the selected uploads for copy.",
+            });
+            getUploadList();
+          })
+          .catch((error) => {
+            setMessage({
+              type: "danger",
+              text: error.message,
+            });
+          })
+          .finally(() => {
+            setShowMessage(true);
+          });
+      });
+  };
+  useEffect(() => {
+    getFolders()
+      .then((res) => {
+        setFolderList(res);
+      })
+      .catch((error) => {
+        setMessage({
+          type: "danger",
+          text: error.message,
+        });
+        setShowMessage(true);
+      });
+    getUploadList();
+  }, [folderId]);
   return (
-    <div className="main-container my-3">
-      <div className="row">
-        <div className="col-lg-8 col-md-12 col-sm-12 col-12">
-          <h1 className="font-size-main-heading">Move upload or folder</h1>
-          <br />
+    <>
+      {showMessage && (
+        <Alert
+          type={message.type}
+          setShow={setShowMessage}
+          message={message.text}
+        />
+      )}
+      <div className="main-container my-3">
+        <h1 className="font-size-main-heading">Move and Copy Upload</h1>
+        <br />
+        <div className="row">
+          <div className="col-12 col-lg-8">
+            <form>
+              <InputContainer
+                type="select"
+                name="folderId"
+                id="organize-upload-folder-id"
+                onChange={(e) => setFolderId(e.target.value)}
+                options={folderList}
+                property="name"
+              >
+                Select a folder whose uploads you want to move/copy:
+              </InputContainer>
+              <br />
+              <InputContainer
+                type="select"
+                name="moveCopyUploadList"
+                id="organize-upload"
+                onChange={handleChange}
+                options={uploadList}
+                property="uploadname"
+                multiple={true}
+              >
+                Select the folder where the content shall be placed:
+              </InputContainer>
+              <br />
+              <InputContainer
+                type="select"
+                name="folderId"
+                id="organize-upload-move-folder"
+                onChange={handleChange}
+                options={folderList}
+                value={moveCopyUploadData.folderId}
+                property="name"
+              >
+                Select the folder where the content shall be placed:
+              </InputContainer>
+              <Button type="submit" onClick={handleMove} className="mt-4">
+                Move
+              </Button>
+              &emsp;
+              <Button type="submit" onClick={handleCopy} className="mt-4">
+                Copy
+              </Button>
+            </form>
+          </div>
         </div>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/src/services/organizeUploads.js
+++ b/src/services/organizeUploads.js
@@ -1,6 +1,5 @@
 /*
  Copyright (C) 2021 Shruti Agarwal (mail2shruti.ag@gmail.com)
-
  SPDX-License-Identifier: GPL-2.0
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
@@ -14,16 +13,31 @@
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-import { getUploadsByFolderId, deleteUploadsApi } from "../api/organizeUploads";
+import {
+  getUploadsByFolderId,
+  deleteUploadsApi,
+  moveUploadApi,
+  copyUploadApi,
+} from "../api/organizeUploads";
 
 export function getUploadsFolderId(folderId) {
   return getUploadsByFolderId(folderId).then((res) => {
     return res;
   });
 }
-
 export function deleteUploadsbyId(deleteId) {
   return deleteUploadsApi(deleteId).then((res) => {
+    return res;
+  });
+}
+export function moveUpload(folderId, id, groupName) {
+  return moveUploadApi(folderId, id, groupName).then((res) => {
+    return res;
+  });
+}
+
+export function copyUpload(folderId, id, groupName) {
+  return copyUploadApi(folderId, id, groupName).then((res) => {
     return res;
   });
 }


### PR DESCRIPTION
## Description

Added the move or copy page in the `organize/uploads`

## Changes

- Added the mechanism for copy and move uploads.

## How to test

visit to `/organize/uploads/move`

## Screenshots
![Screenshot from 2021-07-03 08-25-10](https://user-images.githubusercontent.com/56133783/124341405-b53d1f00-dbd9-11eb-86cb-8218e5e8a0e9.png)
![Screenshot from 2021-07-03 08-25-24](https://user-images.githubusercontent.com/56133783/124341407-b706e280-dbd9-11eb-9b61-76ec99ac8e65.png)
