### PR TITLE
fix(UI): open link in new tab and fix heading

### DIFF
--- a/src/constants/externalLinks.js
+++ b/src/constants/externalLinks.js
@@ -19,4 +19,5 @@
 export const externalLinks = {
   fossologyWiki: "https://github.com/fossology/fossology/wiki",
   jobSchedulerWiki: "https://github.com/fossology/fossology/wiki/Job-Scheduler",
+  fossologyWebsite: "https://www.fossology.org/",
 };

--- a/src/pages/Help/Overview/index.js
+++ b/src/pages/Help/Overview/index.js
@@ -20,6 +20,7 @@ import React from "react";
 import Image from "../../../components/Widgets/Image";
 import microscope from "../../../assets/images/microscope.svg";
 import fossologyFlow from "../../../assets/images/fossologyFlow.svg";
+import { externalLinks } from "../../../constants/externalLinks";
 
 const Overview = () => {
   return (
@@ -131,12 +132,13 @@ const Overview = () => {
           The following resources will provide additional help and information:{" "}
           <br /> <br />
           <a
-            href="https://fossology.org"
+            href={externalLinks.fossologyWebsite}
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noreferrer"
           >
+            {" "}
             FOSSology web site
-          </a>
+          </a>{" "}
           - Where you can find more information and get help on FOSSology.
         </p>
       </div>


### PR DESCRIPTION
## Description

Fixed the heading on move or copy folder and updated the link of fossology website to open in new tab.
Closes #63 

### Changes

- Fixed the heading on move or copy folder
- updated the link of fossology website to open in new tab in the help page


## How to test

Go to `http://localhost:3000/help/overview` and `http://localhost:3000/organize/folders/move`