### PR TITLE
feat(Infra): Introduced Config file for enviornment variables

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,7 @@
+# following keys are required
+
+#backend endpoint
+REACT_APP_SERVER_URL=localhost/repo/api/v1
+
+#for enabling https for backend url
+REACT_APP_HTTPS=false

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "env": {
     "browser": true,
+    "node": true,
     "es2021": true,
     "jest": true
   },

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,12 @@ FROM node:14.15.4-slim
 
 LABEL maintainer="Fossology <fossology@fossology.org>"
 
+ARG REACT_APP_SERVER_URL
+ENV REACT_APP_SERVER_URL=$REACT_APP_SERVER_URL
+
+ARG REACT_APP_HTTPS
+ENV REACT_APP_HTTPS=$REACT_APP_HTTPS
+
 WORKDIR /fossologyui
 
 COPY . .

--- a/README.md
+++ b/README.md
@@ -42,18 +42,23 @@ FOSSology comes with a Dockerfile allowing the containerized execution.
 Run the following commands inside the project directory.
 
 ``` sh
-docker build -t fossologyui:react1.0 .
+docker build \
+-t fossologyui:react1.0 \
+--build-arg REACT_APP_SERVER_URL="localhost/repo/api/v1" \
+--build-arg REACT_APP_HTTPS="false" .
 ```
 
 ``` sh
 docker run -p 3000:3000 fossologyui:react1.0
 ```
 
-The docker image can then be used using http://IP_OF_DOCKER_HOST:3000/ user fossy passwd fossy.
+The docker image can then be used using http://IP_OF_DOCKER_HOST:3000/ user fossy password fossy.
 
 <hr />
 
 In the project directory, you can run:
+
+create  a ```.env``` in root directory of project and copy the contents from ```.env.sample```
 
 #### `yarn`
 #### `yarn start`

--- a/src/constants/endpoints.js
+++ b/src/constants/endpoints.js
@@ -16,7 +16,9 @@
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-const apiUrl = "http://localhost/repo/api/v1";
+const apiUrl = `${
+  process.env.REACT_APP_HTTPS === "true" ? "https" : "http"
+}://${process.env.REACT_APP_SERVER_URL}`;
 
 export const endpoints = {
   jobs: {


### PR DESCRIPTION

## Description

Added support for injecting environment variables.

### Changes

.env.sample -> sample env file
Dockerfile -> added support for injecting args
README.md -> modified installation steps
src/constants/endpoints.js -> using server url from env file


## How to test

after creating ```.env``` file 
use the following config

```
# following keys are required

#backend endpoint
REACT_APP_SERVER_URL=localhost/repo/api/v1

#for enabling https for backend url
REACT_APP_HTTPS=false
```
then proceed with ```yarn``` and ```yarn start```

for docker 
```
docker build \
-t fossologyui:react1.0 \
--build-arg REACT_APP_SERVER_URL="localhost/repo/api/v1" \
--build-arg REACT_APP_HTTPS="false" .
```
```docker run -p 3000:3000 fossologyui:react1.0```

