### PR TITLE
feat(one-shot): Added the analysis, monk and copyright page

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -42,6 +42,9 @@ import UploadFromVcs from "./pages/Upload/Vcs";
 import UploadFromUrl from "./pages/Upload/Url";
 import ImportReport from "./pages/Upload/ImportReport";
 import Instructions from "./pages/Upload/Instructions";
+import OneShotAnalysis from "./pages/Upload/OneShotAnalysis";
+import OneShotCopyright from "./pages/Upload/OneShotCopyright";
+import OneShotMonk from "./pages/Upload/OneShotMonk";
 
 // Jobs Pages
 import AllJobs from "./pages/Jobs/AllJobs";
@@ -62,8 +65,6 @@ import ErrorPage from "./pages/ErrorPage";
 
 // Routes imports
 import { routes } from "./constants/routes";
-import OneShotCopyright from "./pages/Upload/OneShotCopyright";
-import OneShotMonk from "./pages/Upload/OneShotMonk";
 
 const Routes = () => {
   return (
@@ -118,6 +119,11 @@ const Routes = () => {
           exact
           path={routes.upload.instructions}
           component={Instructions}
+        />
+        <PublicLayout
+          exact
+          path={routes.upload.oneShotAnalysis}
+          component={OneShotAnalysis}
         />
         <PublicLayout
           exact

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -62,6 +62,7 @@ import ErrorPage from "./pages/ErrorPage";
 
 // Routes imports
 import { routes } from "./constants/routes";
+import OneShotCopyright from "./pages/Upload/OneShotCopyright";
 
 const Routes = () => {
   return (
@@ -116,6 +117,11 @@ const Routes = () => {
           exact
           path={routes.upload.instructions}
           component={Instructions}
+        />
+        <PublicLayout
+          exact
+          path={routes.upload.oneShotCopyright}
+          component={OneShotCopyright}
         />
 
         {/* Jobs Page */}

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -63,6 +63,7 @@ import ErrorPage from "./pages/ErrorPage";
 // Routes imports
 import { routes } from "./constants/routes";
 import OneShotCopyright from "./pages/Upload/OneShotCopyright";
+import OneShotMonk from "./pages/Upload/OneShotMonk";
 
 const Routes = () => {
   return (
@@ -122,6 +123,11 @@ const Routes = () => {
           exact
           path={routes.upload.oneShotCopyright}
           component={OneShotCopyright}
+        />
+        <PublicLayout
+          exact
+          path={routes.upload.oneShotMonk}
+          component={OneShotMonk}
         />
 
         {/* Jobs Page */}

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -92,6 +92,21 @@ const Header = () => {
                   <NavDropdown.Item as={Link} to={routes.upload.instructions}>
                     Instructions
                   </NavDropdown.Item>
+                  <NavDropdown.Item
+                    as={Link}
+                    to={routes.upload.oneShotAnalysis}
+                  >
+                    One-Shot Analysis
+                  </NavDropdown.Item>
+                  <NavDropdown.Item
+                    as={Link}
+                    to={routes.upload.oneShotCopyright}
+                  >
+                    One-Shot Copyright/Email/URL
+                  </NavDropdown.Item>
+                  <NavDropdown.Item as={Link} to={routes.upload.oneShotMonk}>
+                    One-Shot Monk
+                  </NavDropdown.Item>
                 </NavDropdown>
                 <NavDropdown title="Jobs" id="jobs">
                   <NavDropdown.Item as={Link} to={routes.jobs.myRecentJobs}>

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -28,6 +28,9 @@ export const routes = {
     vcs: "/upload/vcs",
     report: "/upload/report",
     instructions: "/upload/instructions",
+    oneShotAnalysis: "/upload/oneShotAnalysis",
+    oneShotCopyright: "/upload/oneShotCopyright",
+    oneShotMonk: "/upload/oneShotMonk",
   },
   jobs: {
     myRecentJobs: "/jobs/myRecentJobs",

--- a/src/pages/Upload/OneShotAnalysis/index.js
+++ b/src/pages/Upload/OneShotAnalysis/index.js
@@ -1,0 +1,76 @@
+/*
+ Copyright (C) 2021 Shruti Agarwal (mail2shruti.ag@gmail.com)
+
+ SPDX-License-Identifier: GPL-2.0
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+// React imports
+import React from "react";
+import Button from "../../../components/Widgets/Button";
+import InputContainer from "../../../components/Widgets/Input";
+
+const OneShotAnalysis = () => {
+  const handleSubmit = (e) => {
+    e.preventDefault();
+  };
+  const handleChange = () => {};
+  return (
+    <div className="main-container my-3">
+      <div className="row">
+        <div className="col-lg-8 col-md-12 col-sm-12 col-12">
+          <h1 className="font-size-main-heading">One-Shot License Analysis</h1>
+          <br />
+          <div className="font-size-medium">
+            This analyzer allows you to upload a single file for license
+            analysis. The limitations:
+            <ul>
+              <li>
+                The analysis is done in real-time. Large files may take a while.
+                This method is not recommended for files larger than a few
+                hundred kilobytes.
+              </li>
+              <li>
+                Files that contain files are not unpacked. If you upload a 'zip'
+                or 'deb' file, then the binary file will be scanned for licenses
+                and nothing will likely be found.
+              </li>
+              <li>
+                Results are not stored. As soon as you get your results, your
+                uploaded file is removed from the system.
+              </li>
+            </ul>
+          </div>
+          <InputContainer
+            type="file"
+            name="folderId"
+            id="upload-one-shot-analysis"
+            onChange={(e) => handleChange(e)}
+          >
+            Select the file to upload:
+          </InputContainer>
+          <Button
+            type="submit"
+            onClick={(e) => handleSubmit(e)}
+            className="mt-4"
+          >
+            Analyze
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default OneShotAnalysis;

--- a/src/pages/Upload/OneShotCopyright/index.js
+++ b/src/pages/Upload/OneShotCopyright/index.js
@@ -1,0 +1,75 @@
+/*
+ Copyright (C) 2021 Shruti Agarwal (mail2shruti.ag@gmail.com)
+
+ SPDX-License-Identifier: GPL-2.0
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+// React imports
+import React from "react";
+import Button from "../../../components/Widgets/Button";
+import InputContainer from "../../../components/Widgets/Input";
+
+const OneShotCopyright = () => {
+  const handleSubmit = (e) => {
+    e.preventDefault();
+  };
+  const handleChange = () => {};
+  return (
+    <div className="main-container my-3">
+      <div className="row">
+        <div className="col-lg-8 col-md-12 col-sm-12 col-12">
+          <h1 className="font-size-main-heading">
+            One-Shot Copyright/Email/URL Analysis
+          </h1>
+          <br />
+          <div className="font-size-medium">
+            This analyzer allows you to upload a single file for
+            copyright/email/url analysis.
+            <ul>
+              <li>The analysis is done in real-time.</li>
+              <li>
+                Files that contain files are not unpacked. If you upload a
+                container like a gzip file, then only that binary file will be
+                scanned.
+              </li>
+              <li>
+                Results are not stored. As soon as you get your results, your
+                uploaded file is removed from the system.
+              </li>
+            </ul>
+          </div>
+          <InputContainer
+            type="file"
+            name="folderId"
+            id="upload-folder-id"
+            property="name"
+            onChange={(e) => handleChange(e)}
+          >
+            Select the file to upload:
+          </InputContainer>
+          <Button
+            type="submit"
+            onClick={(e) => handleSubmit(e)}
+            className="mt-4"
+          >
+            Analyze
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default OneShotCopyright;

--- a/src/pages/Upload/OneShotMonk/index.js
+++ b/src/pages/Upload/OneShotMonk/index.js
@@ -21,7 +21,7 @@ import React from "react";
 import Button from "../../../components/Widgets/Button";
 import InputContainer from "../../../components/Widgets/Input";
 
-const OneShotCopyright = () => {
+const OneShotMonk = () => {
   const handleSubmit = (e) => {
     e.preventDefault();
   };
@@ -30,19 +30,21 @@ const OneShotCopyright = () => {
     <div className="main-container my-3">
       <div className="row">
         <div className="col-lg-8 col-md-12 col-sm-12 col-12">
-          <h1 className="font-size-main-heading">
-            One-Shot Copyright/Email/URL Analysis
-          </h1>
+          <h1 className="font-size-main-heading">One-Shot Monk</h1>
           <br />
           <div className="font-size-medium">
-            This analyzer allows you to upload a single file for
-            copyright/email/url analysis.
+            This analyzer allows you to upload a single file for license
+            analysis. The limitations:
             <ul>
-              <li>The analysis is done in real-time.</li>
               <li>
-                Files that contain files are not unpacked. If you upload a
-                container like a gzip file, then only that binary file will be
-                scanned.
+                The analysis is done in real-time. Large files may take a while.
+                This method is not recommended for files larger than a few
+                hundred kilobytes.
+              </li>
+              <li>
+                Files that contain files are not unpacked. If you upload a 'zip'
+                or 'deb' file, then the binary file will be scanned for licenses
+                and nothing will likely be found.
               </li>
               <li>
                 Results are not stored. As soon as you get your results, your
@@ -53,7 +55,7 @@ const OneShotCopyright = () => {
           <InputContainer
             type="file"
             name="folderId"
-            id="upload-one-shot-copyright"
+            id="upload-one-shot-monk"
             onChange={(e) => handleChange(e)}
           >
             Select the file to upload:
@@ -71,4 +73,4 @@ const OneShotCopyright = () => {
   );
 };
 
-export default OneShotCopyright;
+export default OneShotMonk;


### PR DESCRIPTION
## Description

Added the one-shot license analysis, one-shot copyright and one-shot monk page.

## Changes

- Created the pages for One shot.
- Added the routes.

## How to test

Visit to `upload/oneShotAnalysis`, `upload/oneShotLicense`, `upload/oneShotMonk`

## Screenshots
![Screenshot from 2021-07-04 02-36-52](https://user-images.githubusercontent.com/56133783/124366894-c1c08680-dc70-11eb-9a85-4cdcee518de2.png)
![Screenshot from 2021-07-04 02-36-58](https://user-images.githubusercontent.com/56133783/124366896-c38a4a00-dc70-11eb-9ada-4d7904eb400b.png)
![Screenshot from 2021-07-04 02-37-04](https://user-images.githubusercontent.com/56133783/124366897-c422e080-dc70-11eb-8a4d-237b9ac88df4.png)
