### PR TITLE
fix(api): remove the redundancy of credentials

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -1,6 +1,6 @@
 /*
- Copyright (C) 2021 Aman Dwivedi (aman.dwivedi5@gmail.com)
- 
+ Copyright (C) 2021 Aman Dwivedi (aman.dwivedi5@gmail.com), Shruti Agarwal (mail2shruti.ag@gmail.com)
+
  SPDX-License-Identifier: GPL-2.0
 
  This program is free software; you can redistribute it and/or
@@ -30,7 +30,6 @@ export const fetchTokenApi = (username, password) => {
   return sendRequest({
     url,
     method: "POST",
-    credentials: "include",
     body: {
       username,
       password,

--- a/src/api/browse.js
+++ b/src/api/browse.js
@@ -33,7 +33,6 @@ export const browseFiles = async ({
   return sendRequest({
     url,
     method: "GET",
-    credentials: "include",
     headers: {
       Authorization: token,
       page,

--- a/src/api/folders.js
+++ b/src/api/folders.js
@@ -25,7 +25,6 @@ export const getAllFoldersApi = async () => {
   return sendRequest({
     url,
     method: "GET",
-    credentials: "include",
     headers: {
       Authorization: await getToken(),
     },
@@ -37,7 +36,6 @@ export const getSingleFolderApi = async (id) => {
   return sendRequest({
     url,
     method: "GET",
-    credentials: "include",
     headers: {
       Authorization: await getToken(),
     },
@@ -49,7 +47,6 @@ export const deleteFolderApi = async (id) => {
   return sendRequest({
     url,
     method: "DELETE",
-    credentials: "include",
     headers: {
       Authorization: await getToken(),
     },
@@ -65,7 +62,6 @@ export const createFolderApi = async (
   return sendRequest({
     url,
     method: "POST",
-    credentials: "include",
     headers: {
       Authorization: await getToken(),
       parentFolder,
@@ -80,7 +76,6 @@ export const editFolderApi = async (name, description, id) => {
   return sendRequest({
     url,
     method: "PATCH",
-    credentials: "include",
     headers: {
       Authorization: await getToken(),
       name,
@@ -94,7 +89,6 @@ export const moveCopyFolderApi = async (parent, id, action) => {
   return sendRequest({
     url,
     method: "PUT",
-    credentials: "include",
     headers: {
       Authorization: await getToken(),
       parent,

--- a/src/api/getFolder.js
+++ b/src/api/getFolder.js
@@ -24,7 +24,6 @@ export const getAllFolders = () => {
   return sendRequest({
     url,
     method: "GET",
-    credentials: "include",
     headers: {
       Authorization: getToken(),
     },

--- a/src/api/jobs.js
+++ b/src/api/jobs.js
@@ -1,6 +1,5 @@
 /*
  Copyright (C) 2021 Aman Dwivedi (aman.dwivedi5@gmail.com)
- 
  SPDX-License-Identifier: GPL-2.0
 
  This program is free software; you can redistribute it and/or
@@ -24,6 +23,5 @@ export const getJobApi = ({ jobId }) => {
   return sendRequest({
     url,
     method: "GET",
-    credentials: "include",
   });
 };

--- a/src/api/search.js
+++ b/src/api/search.js
@@ -37,7 +37,6 @@ export const searchFiles = async ({
   return sendRequest({
     url,
     method: "GET",
-    credentials: "include",
     headers: {
       Authorization: token,
       groupName,

--- a/src/api/sendRequest.js
+++ b/src/api/sendRequest.js
@@ -20,7 +20,7 @@ import { stringify } from "query-string";
 const sendRequest = ({
   url,
   method,
-  credentials = null,
+  credentials = "include",
   body,
   headers = {},
   queryParams,

--- a/src/api/upload.js
+++ b/src/api/upload.js
@@ -37,7 +37,6 @@ export const createUpload = async (
   return sendRequest({
     url,
     method: "POST",
-    credentials: "include",
     isMultipart: true,
     headers: {
       Authorization: token,
@@ -62,7 +61,6 @@ export const scheduleAnalysis = async (folderId, uploadId, scanData) => {
   return sendRequest({
     url,
     method: "POST",
-    credentials: "include",
     headers: {
       Authorization: token,
       folderId,
@@ -103,7 +101,6 @@ export const getUploadById = async (uploadId) => {
   return sendRequest({
     url,
     method: "GET",
-    credentials: "include",
     headers: {
       Authorization: token,
       uploadId,

--- a/src/api/users.js
+++ b/src/api/users.js
@@ -1,6 +1,6 @@
 /*
- Copyright (C) 2021 Aman Dwivedi (aman.dwivedi5@gmail.com)
- 
+ Copyright (C) 2021 Aman Dwivedi (aman.dwivedi5@gmail.com), Shruti Agarwal (mail2shruti.ag@gmail.com)
+
  SPDX-License-Identifier: GPL-2.0
 
  This program is free software; you can redistribute it and/or
@@ -25,7 +25,6 @@ export const getUserSelfApi = async () => {
   return sendRequest({
     url,
     method: "GET",
-    credentials: "include",
     headers: {
       Authorization: await getToken(),
     },


### PR DESCRIPTION
## Description

Remove the redundancy of credentials in the api.

## Changes

- Remove the `credentials="include"` from all apis.
- Set the initial value of credentials to include.
