### PR TITLE
fix(alert): replace the bootstrap alerts with snackbars

### DIFF
--- a/src/pages/Organize/Folder/Unlink/index.js
+++ b/src/pages/Organize/Folder/Unlink/index.js
@@ -17,9 +17,10 @@
 */
 
 import React, { useState, useEffect } from "react";
-import { Spinner, Alert } from "react-bootstrap";
+import { Spinner } from "react-bootstrap";
 import InputContainer from "../../../../components/Widgets/Input";
 import Button from "../../../../components/Widgets/Button";
+import Alert from "../../../../components/Widgets/Alert";
 import { getAllFolders, deleteFolder } from "../../../../services/folders";
 
 const UnlinkFolder = () => {
@@ -98,12 +99,10 @@ const UnlinkFolder = () => {
     <>
       {showMessage && (
         <Alert
-          variant={message.type}
-          onClose={() => setShowMessage(false)}
-          dismissible
-        >
-          <p>{message.text}</p>
-        </Alert>
+          type={message.type}
+          onClose={setShowMessage}
+          message={message.text}
+        />
       )}
       <div className="main-container my-3">
         <h1 className="font-size-main-heading text-center">Unlink folder</h1>

--- a/src/pages/Organize/Uploads/Delete/index.js
+++ b/src/pages/Organize/Uploads/Delete/index.js
@@ -1,4 +1,4 @@
-/***************************************************************
+/*
  Copyright (C) 2021 Shruti Agarwal (mail2shruti.ag@gmail.com)
 
  SPDX-License-Identifier: GPL-2.0
@@ -14,12 +14,13 @@
  You should have received a copy of the GNU General Public License along
  with this program; if not, write to the Free Software Foundation, Inc.,
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-***************************************************************/
+*/
 
 import React, { useState, useEffect } from "react";
-import { Spinner, Alert } from "react-bootstrap";
+import { Spinner } from "react-bootstrap";
 import InputContainer from "../../../../components/Widgets/Input";
 import Button from "../../../../components/Widgets/Button";
+import Alert from "../../../../components/Widgets/Alert";
 import { getAllFolders } from "../../../../services/folders";
 import {
   getUploadsFolderId,
@@ -108,12 +109,10 @@ const UploadDelete = () => {
     <>
       {showMessage && (
         <Alert
-          variant={message.type}
-          onClose={() => setShowMessage(false)}
-          dismissible
-        >
-          <p>{message.text}</p>
-        </Alert>
+          type={message.type}
+          onClose={setShowMessage}
+          message={message.text}
+        />
       )}
       <div className="main-container my-3">
         <h1 className="font-size-main-heading mb-4">Delete Uploaded File</h1>


### PR DESCRIPTION
## Description

Fixed the react bootstrap alerts in delete upload and unlink upload.

## Changes

- Replaced the bootstrap alert with Snackbar

## Screenshots

![Screenshot from 2021-07-08 11-34-13](https://user-images.githubusercontent.com/56133783/124872109-78f72d80-dfe2-11eb-9b05-2c64d88cd90c.png)
![Screenshot from 2021-07-08 11-37-24](https://user-images.githubusercontent.com/56133783/124872115-7ac0f100-dfe2-11eb-95e3-21a67ac86614.png)
