### PR TITLE
feat(ci): Mark PRs with conflicts

### DIFF
--- a/.github/workflows/conflict-check.yml
+++ b/.github/workflows/conflict-check.yml
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: GPL-2.0
+#
+# SPDX-FileCopyrightText: 2021 Gaurav Mishra <mishra.gaurav@siemens.com>
+# SPDX-FileCopyrightText: 2021 Siemens AG
+
+name: Check PRs for conflicts
+
+on:
+  pull_request_target:
+    types: [synchronize]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if PRs are dirty
+        uses: eps1lon/actions-label-merge-conflict@releases/2.x
+        with:
+          dirtyLabel: "has merge conflicts"
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          commentOnDirty: |
+            This pull request has conflicts, please rebase to resolve those before we can evaluate the pull request.
+


### PR DESCRIPTION
## Description

Use GitHub actions to mark PRs with merge conflicts with label "has merge conflicts".

### Changes

1. Create a new GitHub Action workflow which scans for dirty PRs when a merge to master happens.

## How to test

Check https://github.com/fossology/fossology/pull/1993