### PR TITLE
fix(query-params): sanitize url query parameters

### DIFF
--- a/src/api/licenses.js
+++ b/src/api/licenses.js
@@ -26,7 +26,7 @@ import sendRequest from "./sendRequest";
 
 // Fetching the licenses with their kind i.e (candidate, main, all)
 const getAllLicenseApi = ({ page, limit, groupName, kind }) => {
-  const url = endpoints.license.get(kind);
+  const url = endpoints.license.get();
   return sendRequest({
     url,
     method: "GET",
@@ -35,6 +35,9 @@ const getAllLicenseApi = ({ page, limit, groupName, kind }) => {
       page,
       limit,
       groupName,
+    },
+    queryParams: {
+      kind,
     },
   });
 };

--- a/src/api/organizeUploads.js
+++ b/src/api/organizeUploads.js
@@ -59,6 +59,10 @@ export const moveUploadApi = (folderId, id, groupName) => {
       folderId,
       groupName,
     },
+    queryParams: {
+      // Set the recursive false to reduce amount of data in response
+      recursive: false,
+    },
   });
 };
 
@@ -72,6 +76,10 @@ export const copyUploadApi = (folderId, id, groupName) => {
       Authorization: getToken(),
       folderId,
       groupName,
+    },
+    queryParams: {
+      // Set the recursive false to reduce amount of data in response
+      recursive: false,
     },
   });
 };

--- a/src/constants/endpoints.js
+++ b/src/constants/endpoints.js
@@ -59,9 +59,8 @@ const endpoints = {
     uploads: {
       get: (folder) => `${apiUrl}/uploads?folderId=${folder}`,
       delete: (deleteId) => `${apiUrl}/uploads/${deleteId}`,
-      // Set the recursive false to reduce amount of data in response
-      move: (moveId) => `${apiUrl}/uploads/${moveId}?recursive=false`,
-      copy: (copyId) => `${apiUrl}/uploads/${copyId}?recursive=false`,
+      move: (moveId) => `${apiUrl}/uploads/${moveId}`,
+      copy: (copyId) => `${apiUrl}/uploads/${copyId}`,
     },
   },
   admin: {
@@ -71,7 +70,7 @@ const endpoints = {
     },
   },
   license: {
-    get: (kind) => `${apiUrl}/license?kind=${kind}`,
+    get: () => `${apiUrl}/license`,
   },
 };
 


### PR DESCRIPTION
## Description

Sanitize URL query parameters using `query-string` library. Also the API endpoints should not have hardcoded query parameters.

### Changes

- Sanitized URL query parameters

## How to test

Test updated API