### PR TITLE
fix(schedule-jobs): fix the upload list on schedule jobs page

### DIFF
--- a/src/pages/Jobs/ScheduleAgents/index.jsx
+++ b/src/pages/Jobs/ScheduleAgents/index.jsx
@@ -165,7 +165,7 @@ const ScheduleAgents = () => {
       ...initialBrowseData,
       folderId: scheduleAnalysisData.folderId,
     }).then((res) => {
-      setUploadList(res);
+      setUploadList(res.res);
     });
   }, [scheduleAnalysisData.folderId]);
 


### PR DESCRIPTION
## Description

The addition of pagination feature in browse page modified the uploaded files list function which broke the schedule jobs page.

### Changes

- Fixed the select the upload to analyze component on schedule jobs page

## Screenshot
![image](https://user-images.githubusercontent.com/54680709/125735482-9abb5fbd-16fb-4146-8f33-bb90f3c0d8b9.png)


## How to test

Go to`http://localhost:3000/jobs/scheduleAgents`
