### PR TITLE
feat(license): added the candidate new license page

### DIFF
--- a/src/Routes.jsx
+++ b/src/Routes.jsx
@@ -58,7 +58,8 @@ import CreateFolder from "pages/Organize/Folder/Create";
 import EditFolder from "pages/Organize/Folder/Edit";
 import MoveFolder from "pages/Organize/Folder/Move";
 import UnlinkFolder from "pages/Organize/Folder/Unlink";
-import AdviceLicenses from "pages/Organize/License/index";
+import AdviceLicenses from "pages/Organize/License/CandidateLicense";
+import AddCandidateLicense from "pages/Organize/License/Create";
 import UploadEdit from "pages/Organize/Uploads/Edit";
 import UploadMove from "pages/Organize/Uploads/Move";
 import UploadDelete from "pages/Organize/Uploads/Delete";
@@ -190,8 +191,13 @@ const Routes = () => {
         />
         <PrivateLayout
           exact
-          path={routes.organize.licenses}
+          path={routes.organize.licenses.candidate}
           component={AdviceLicenses}
+        />
+        <PrivateLayout
+          exact
+          path={routes.organize.licenses.create}
+          component={AddCandidateLicense}
         />
         <PrivateLayout
           exact

--- a/src/api/browse.js
+++ b/src/api/browse.js
@@ -26,7 +26,7 @@ import { getToken } from "shared/authHelper";
 import sendRequest from "./sendRequest";
 
 // Fetching all the Uploads with the give parameters of page, limit
-const getBrowseDataApi = ({ folderId, page, limit, groupName, recursive }) => {
+const getBrowseDataApi = ({ folderId, page, limit, recursive }) => {
   const url = endpoints.browse.get();
   return sendRequest({
     url,
@@ -35,7 +35,6 @@ const getBrowseDataApi = ({ folderId, page, limit, groupName, recursive }) => {
       Authorization: getToken(),
       page,
       limit,
-      groupName,
     },
     queryParams: {
       folderId,
@@ -45,7 +44,6 @@ const getBrowseDataApi = ({ folderId, page, limit, groupName, recursive }) => {
 };
 
 getBrowseDataApi.propTypes = {
-  groupName: PropTypes.string,
   page: PropTypes.number,
   limit: PropTypes.number,
   folderId: PropTypes.number,

--- a/src/api/licenses.js
+++ b/src/api/licenses.js
@@ -25,7 +25,7 @@ import { getToken } from "shared/authHelper";
 import sendRequest from "./sendRequest";
 
 // Fetching the licenses with their kind i.e (candidate, main, all)
-const getAllLicenseApi = ({ page, limit, kind }) => {
+export const getAllLicenseApi = ({ page, limit, groupName, kind }) => {
   const url = endpoints.license.get();
   return sendRequest({
     url,
@@ -34,6 +34,7 @@ const getAllLicenseApi = ({ page, limit, kind }) => {
       Authorization: getToken(),
       page,
       limit,
+      groupName,
     },
     queryParams: {
       kind,
@@ -41,4 +42,30 @@ const getAllLicenseApi = ({ page, limit, kind }) => {
   });
 };
 
-export default getAllLicenseApi;
+export const createCandidateLicenseApi = ({
+  shortName,
+  fullName,
+  text,
+  risk,
+  licenseUrl,
+  mergeRequest,
+}) => {
+  const url = endpoints.license.createCandidateLicense();
+  return sendRequest({
+    url,
+    method: "POST",
+    headers: {
+      Authorization: getToken(),
+      groupName: "",
+    },
+    body: {
+      shortName,
+      fullName,
+      text,
+      risk,
+      url: licenseUrl,
+      isCandidate: true,
+      mergeRequest,
+    },
+  });
+};

--- a/src/api/licenses.js
+++ b/src/api/licenses.js
@@ -25,7 +25,7 @@ import { getToken } from "shared/authHelper";
 import sendRequest from "./sendRequest";
 
 // Fetching the licenses with their kind i.e (candidate, main, all)
-export const getAllLicenseApi = ({ page, limit, groupName, kind }) => {
+export const getAllLicenseApi = ({ page, limit, kind }) => {
   const url = endpoints.license.get();
   return sendRequest({
     url,
@@ -34,7 +34,6 @@ export const getAllLicenseApi = ({ page, limit, groupName, kind }) => {
       Authorization: getToken(),
       page,
       limit,
-      groupName,
     },
     queryParams: {
       kind,
@@ -56,7 +55,6 @@ export const createCandidateLicenseApi = ({
     method: "POST",
     headers: {
       Authorization: getToken(),
-      groupName: "",
     },
     body: {
       shortName,

--- a/src/api/search.js
+++ b/src/api/search.js
@@ -27,7 +27,6 @@ import sendRequest from "./sendRequest";
 
 // Fetching all the uploads on the basis of search criteria
 const searchApi = ({
-  groupName,
   searchType,
   uploadId,
   filename,
@@ -43,7 +42,7 @@ const searchApi = ({
     method: "GET",
     headers: {
       Authorization: getToken(),
-      groupName,
+
       searchType,
       uploadId,
       filename,
@@ -57,7 +56,6 @@ const searchApi = ({
 };
 
 searchApi.propTypes = {
-  groupName: PropTypes.string,
   searchType: PropTypes.string,
   uploadId: PropTypes.number,
   filename: PropTypes.string,

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -196,7 +196,10 @@ const Header = () => {
                       </NavDropdown.Item>
                     </div>
                   </DropdownButton>
-                  <NavDropdown.Item as={Link} to={routes.organize.licenses}>
+                  <NavDropdown.Item
+                    as={Link}
+                    to={routes.organize.licenses.candidate}
+                  >
                     Licenses
                   </NavDropdown.Item>
                   <DropdownButton

--- a/src/constants/endpoints.js
+++ b/src/constants/endpoints.js
@@ -71,6 +71,7 @@ const endpoints = {
   },
   license: {
     get: () => `${apiUrl}/license`,
+    createCandidateLicense: () => `${apiUrl}/license`,
   },
 };
 

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -46,7 +46,10 @@ const routes = {
       move: "/organize/folders/move",
       unlinkContent: "/organize/folders/unlinkContent",
     },
-    licenses: "/organize/licenses",
+    licenses: {
+      create: "/organize/license/create",
+      candidate: "/organize/license/candidate",
+    },
     uploads: {
       delete: "/organize/uploads/delete",
       edit: "/organize/uploads/edit",

--- a/src/pages/Organize/License/CandidateLicense/index.jsx
+++ b/src/pages/Organize/License/CandidateLicense/index.jsx
@@ -23,7 +23,7 @@ import { useHistory } from "react-router-dom";
 import { Alert, Button, InputContainer } from "components/Widgets";
 
 // Required functions for calling APIs
-import getAllLicense from "services/licenses";
+import { getAllLicense } from "services/licenses";
 
 // Routes
 import routes from "constants/routes";
@@ -151,7 +151,7 @@ const AdviceLicenses = () => {
             </table>
             <Button
               type="button"
-              onClick={() => history.push(routes.admin.license.create)}
+              onClick={() => history.push(routes.organize.licenses.create)}
               className="mt-4"
             >
               New License

--- a/src/pages/Organize/License/Create/index.jsx
+++ b/src/pages/Organize/License/Create/index.jsx
@@ -137,11 +137,11 @@ const AddCandidateLicense = () => {
                 Full name
               </InputContainer>
               <div className="my-2">
-                <label htmlFor="upload" className="font-demi font-15">
+                <label htmlFor="upload" className="font-demi w-100">
                   Reference Text
                   <textarea
                     name="text"
-                    className="form-control"
+                    className="form-control font-regular"
                     value={createCandidateLicense.text}
                     id="organize-add-license-text"
                     rows="3"

--- a/src/pages/Organize/License/Create/index.jsx
+++ b/src/pages/Organize/License/Create/index.jsx
@@ -1,0 +1,201 @@
+/*
+ Copyright (C) 2021 Shruti Agarwal (mail2shruti.ag@gmail.com)
+
+ SPDX-License-Identifier: GPL-2.0
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+import React, { useState } from "react";
+
+// Widgets
+import { Alert, Button, InputContainer, Spinner } from "components/Widgets";
+
+// Required functions for calling APIs
+import { createCandidateLicense } from "services/licenses";
+
+const AddCandidateLicense = () => {
+  const options = [
+    {
+      id: 1,
+      value: 1,
+    },
+    {
+      id: 2,
+      value: 2,
+    },
+    {
+      id: 3,
+      value: 3,
+    },
+    {
+      id: 4,
+      value: 4,
+    },
+    {
+      id: 5,
+      value: 5,
+    },
+  ];
+  const initialState = {
+    shortName: "",
+    fullName: "",
+    text: "",
+    risk: 1,
+    licenseUrl: "",
+    mergeRequest: false,
+  };
+  const initialMessage = {
+    type: "success",
+    text: "",
+  };
+
+  // Data required for creating the candidate license
+  const [createLicenseData, setCreateLicenseData] = useState(initialState);
+
+  // State Variables for handling Error Boundaries
+  const [loading, setLoading] = useState(false);
+  const [showMessage, setShowMessage] = useState(false);
+  const [message, setMessage] = useState(initialMessage);
+
+  const handleChange = (e) => {
+    if (e.target.type === "checkbox") {
+      setCreateLicenseData({
+        ...createLicenseData,
+        [e.target.name]: e.target.checked,
+      });
+    } else {
+      setCreateLicenseData({
+        ...createLicenseData,
+        [e.target.name]: e.target.value,
+      });
+    }
+  };
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    setLoading(true);
+    createCandidateLicense(createLicenseData)
+      .then(() => {
+        setMessage({
+          type: "success",
+          text: "Successfully created the license",
+        });
+      })
+      .catch((error) => {
+        setMessage({
+          type: "danger",
+          text: error.message,
+        });
+      })
+      .finally(() => {
+        setLoading(false);
+        setShowMessage(true);
+      });
+  };
+  return (
+    <>
+      {showMessage && (
+        <Alert
+          type={message.type}
+          setShow={setShowMessage}
+          message={message.text}
+        />
+      )}
+      <div className="main-container my-3">
+        <div className="row">
+          <div className="col-lg-8 col-md-12 col-sm-12 col-12">
+            <h1 className="font-size-main-heading">Add License</h1>
+            <br />
+            <form>
+              <InputContainer
+                value={createLicenseData.shortName}
+                name="shortName"
+                type="text"
+                id="organize-add-license-short-name"
+                placeholder="Must be unique"
+                onChange={handleChange}
+              >
+                Short name
+              </InputContainer>
+              <InputContainer
+                value={createCandidateLicense.fullName}
+                name="fullName"
+                type="text"
+                id="organize-add-license-full-name"
+                onChange={handleChange}
+              >
+                Full name
+              </InputContainer>
+              <div className="my-2">
+                <label htmlFor="upload" className="font-demi font-15">
+                  Reference Text
+                  <textarea
+                    name="text"
+                    className="form-control"
+                    value={createCandidateLicense.text}
+                    id="organize-add-license-text"
+                    rows="3"
+                    onChange={(e) => handleChange(e)}
+                  />
+                </label>
+              </div>
+              <InputContainer
+                value={createCandidateLicense.licenseUrl}
+                name="licenseUrl"
+                type="text"
+                id="organize-add-license-text-url"
+                onChange={handleChange}
+              >
+                URL
+              </InputContainer>
+              <InputContainer
+                options={options}
+                name="risk"
+                type="select"
+                property="value"
+                id="organize-add-license-risk-level"
+                onChange={handleChange}
+              >
+                Risk level
+              </InputContainer>
+              <InputContainer
+                type="checkbox"
+                checked={createLicenseData.mergeRequest}
+                name="mergeRequest"
+                id="organize-add-license-merge-request"
+                onChange={(e) => handleChange(e)}
+              >
+                Merge Request
+              </InputContainer>
+              <Button type="submit" onClick={handleSubmit} className="mt-4">
+                {loading ? (
+                  <Spinner
+                    as="span"
+                    animation="border"
+                    size="sm"
+                    role="status"
+                    aria-hidden="true"
+                  />
+                ) : (
+                  "Add License"
+                )}
+              </Button>
+            </form>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default AddCandidateLicense;

--- a/src/services/licenses.js
+++ b/src/services/licenses.js
@@ -16,13 +16,17 @@
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-import getAllLicenseApi from "api/licenses";
+import { getAllLicenseApi, createCandidateLicenseApi } from "api/licenses";
 
 // Fetching the licenses with their kind i.e (candidate, main, all)
-const getAllLicense = (licenseData) => {
+export const getAllLicense = (licenseData) => {
   return getAllLicenseApi(licenseData).then((res) => {
     return res;
   });
 };
 
-export default getAllLicense;
+export const createCandidateLicense = (licenseData) => {
+  return createCandidateLicenseApi(licenseData).then((res) => {
+    return res;
+  });
+};


### PR DESCRIPTION
## Description

Added the create new license page for candidate.

### Changes

- Added the endpoint and route for createCandidateLicense in constant folder.
- Created the function for it in services and api.
- Created the page for it.
- Shifted the listing of license page in organize into the License folder.

### Screenshots
![Screenshot from 2021-07-21 09-34-41](https://user-images.githubusercontent.com/56133783/126429220-ea86ad7e-df61-4775-aa42-c55b21aeb6b4.png)
![Screenshot from 2021-07-21 12-08-32](https://user-images.githubusercontent.com/56133783/126443158-120ba668-10ea-4476-b03b-1090389e3580.png)


## How to test

Visit to `/organize/license/create`