### PR TITLE
feat(alert): alert message on homepage for logout error

### DIFF
--- a/src/api/sendRequest.js
+++ b/src/api/sendRequest.js
@@ -108,7 +108,10 @@ const sendRequest = ({
         body: json,
       };
       if (json.code === 403) {
-        return logout();
+        if (json.message) {
+          return logout({ message: json.message });
+        }
+        return logout({ message: "Requested resource is forbidden" });
       }
       return Promise.reject(error);
     });

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -360,7 +360,9 @@ const Header = () => {
                   User: <b>{getUserName()}</b>
                 </Dropdown.Item>
                 <Dropdown.Divider />
-                <Dropdown.Item onClick={logout}>Log out</Dropdown.Item>
+                <Dropdown.Item onClick={() => logout(null)}>
+                  Log out
+                </Dropdown.Item>
                 <Dropdown.Divider />
                 <Dropdown.Item onClick={() => setTheme("light")}>
                   Light Theme

--- a/src/pages/Home/index.jsx
+++ b/src/pages/Home/index.jsx
@@ -17,7 +17,7 @@
 */
 
 // React Imports
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 
 // Title
 import Title from "components/Title";
@@ -25,6 +25,8 @@ import Title from "components/Title";
 // External library imports
 import { useHistory } from "react-router-dom";
 import { Form, Row, Col } from "react-bootstrap";
+import queryString from "query-string";
+import PropTypes from "prop-types";
 
 // Required functions for calling APIs
 import fetchToken from "services/auth";
@@ -46,7 +48,7 @@ import Features from "./Features";
 // CSS imports
 import LoginForm from "./style";
 
-const Home = () => {
+const Home = ({ location }) => {
   const history = useHistory();
 
   // Data required for user login
@@ -79,6 +81,16 @@ const Home = () => {
         setShowError(true);
       });
   };
+
+  useEffect(() => {
+    const queryParams = queryString.parse(location.search);
+    const { message } = queryParams;
+    if (message) {
+      setErrorMessage(message);
+      setShowError(true);
+    }
+    window.history.replaceState(null, null, window.location.pathname);
+  }, [location.search]);
 
   return (
     <>
@@ -187,6 +199,12 @@ const Home = () => {
       </div>
     </>
   );
+};
+
+Home.propTypes = {
+  location: PropTypes.shape({
+    search: PropTypes.string,
+  }),
 };
 
 export default Home;

--- a/src/shared/authHelper.js
+++ b/src/shared/authHelper.js
@@ -16,6 +16,8 @@
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
+// query-string library to sanitize url
+import { stringify } from "query-string";
 // Routes
 import routes from "constants/routes";
 
@@ -42,12 +44,16 @@ export const isAuth = () => {
 };
 
 // Logging out the user
-export const logout = () => {
+export const logout = (message) => {
   removeCookie("token");
   removeLocalStorage("user");
   removeLocalStorage("groups");
   removeLocalStorage("currentGroup");
-  window.location.href = routes.home;
+  let Url = routes.home;
+  if (message) {
+    Url = `${routes.home}?${stringify(message)}`;
+  }
+  window.location.href = Url;
 };
 
 // Updating the user info


### PR DESCRIPTION
## Description

In case of a 403 error, displayed the body of the response as a snack bar on the homepage. 
Previous discussion on #117 

### Changes

- Updated logout function to accept error message as a parameter
- Updated home page to display the error message from URL query parameter

## Screenshot
![image](https://user-images.githubusercontent.com/54680709/126998937-c671bdf9-5d29-4482-8b67-77f1de3e573d.png)

## How to test

Go to `http://localhost:3000/?message=Requested%20resource%20is%20forbidden`
Or make a request which returns a 403 error code.