### PR TITLE
fix(errors): Added the error checks in deleteUploads

### DIFF
--- a/src/pages/Organize/Uploads/Delete/index.jsx
+++ b/src/pages/Organize/Uploads/Delete/index.jsx
@@ -83,7 +83,7 @@ const UploadDelete = () => {
   const handleSubmit = (e) => {
     e.preventDefault();
     setLoading(true);
-    if (deleteUploadFolderData.uploadId.length > 0) {
+    if (deleteUploadFolderData?.uploadId?.length > 0) {
       deleteUploadFolderData?.uploadId?.forEach((id) => {
         return deleteUploadsbyId(parseInt(id, 10))
           .then(() => {
@@ -105,6 +105,13 @@ const UploadDelete = () => {
             setLoading(false);
             setShowMessage(true);
           });
+      });
+    } else {
+      setLoading(false);
+      setShowMessage(true);
+      setMessage({
+        type: "danger",
+        text: "Select the uploads to delete",
       });
     }
   };


### PR DESCRIPTION
## Description

Code is getting broken if no upload is selected to delete.

### Changes

Added the error checks in deleteUploads.

## How to test

- visit to `/organize/uploads/delete`.
- click on delete button without selecting any upload to delete.

## Screenshots
![Screenshot from 2021-07-28 04-30-46](https://user-images.githubusercontent.com/56133783/127238713-2acf06df-e5b4-43f5-ba4a-5f0daa23b607.png)
![Screenshot from 2021-07-28 04-31-21](https://user-images.githubusercontent.com/56133783/127238707-3df081bc-aa68-4107-95e8-c6db0b7b81d9.png)
