### PR TITLE
feat(reuse): add all reuse options and update corresponding api

### DIFF
--- a/src/api/folders.js
+++ b/src/api/folders.js
@@ -25,7 +25,7 @@ import { getToken } from "shared/authHelper";
 import sendRequest from "./sendRequest";
 
 // Fetching all the folders
-export const getAllFoldersApi = () => {
+export const getAllFoldersApi = (groupName) => {
   const url = endpoints.folders.getAll();
   return sendRequest({
     url,
@@ -33,6 +33,7 @@ export const getAllFoldersApi = () => {
     headers: {
       Authorization: getToken(),
     },
+    groupName,
   });
 };
 

--- a/src/api/organizeUploads.js
+++ b/src/api/organizeUploads.js
@@ -25,8 +25,8 @@ import { getToken } from "shared/authHelper";
 import sendRequest from "./sendRequest";
 
 // Getting uploads with folder id
-export const getUploadsByFolderIdApi = (id, groupName) => {
-  const url = endpoints.organize.uploads.get(id);
+export const getUploadsByFolderIdApi = (id, groupName, recursive) => {
+  const url = endpoints.organize.uploads.get();
   return sendRequest({
     url,
     method: "GET",
@@ -34,6 +34,10 @@ export const getUploadsByFolderIdApi = (id, groupName) => {
       Authorization: getToken(),
     },
     groupName,
+    queryParams: {
+      recursive,
+      folderId: id,
+    },
   });
 };
 

--- a/src/api/organizeUploads.js
+++ b/src/api/organizeUploads.js
@@ -25,7 +25,7 @@ import { getToken } from "shared/authHelper";
 import sendRequest from "./sendRequest";
 
 // Getting uploads with folder id
-export const getUploadsByFolderIdApi = (id) => {
+export const getUploadsByFolderIdApi = (id, groupName) => {
   const url = endpoints.organize.uploads.get(id);
   return sendRequest({
     url,
@@ -33,6 +33,7 @@ export const getUploadsByFolderIdApi = (id) => {
     headers: {
       Authorization: getToken(),
     },
+    groupName,
   });
 };
 

--- a/src/api/upload.js
+++ b/src/api/upload.js
@@ -75,7 +75,14 @@ export const scheduleAnalysisApi = (folderId, uploadId, scanData) => {
   const { bucket, copyrightEmailAuthor, ecc, keyword, mime, monk, nomos, ojo } =
     scanData?.analysis;
   const { nomosMonk, bulkReused, newScanner, ojoDecider } = scanData?.decider;
-  const { reuseUpload, reuseGroup, reuseMain, reuseEnhanced } = scanData?.reuse;
+  const {
+    reuseUpload,
+    reuseGroup,
+    reuseMain,
+    reuseEnhanced,
+    reuseReport,
+    reuseCopyright,
+  } = scanData?.reuse;
   return sendRequest({
     url,
     method: "POST",
@@ -107,6 +114,8 @@ export const scheduleAnalysisApi = (folderId, uploadId, scanData) => {
         reuse_group: reuseGroup,
         reuse_main: reuseMain,
         reuse_enhanced: reuseEnhanced,
+        reuse_report: reuseReport,
+        reuse_copyright: reuseCopyright,
       },
     },
   });

--- a/src/components/Upload/CommonFields/UploadReuse/index.jsx
+++ b/src/components/Upload/CommonFields/UploadReuse/index.jsx
@@ -16,19 +16,110 @@
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-import React from "react";
+import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 
 // Widgets
 import { InputContainer, Tooltip } from "components/Widgets";
 
-function UploadReuse({ reuse, handleChange }) {
+// Required services for calling APIs
+import { getAllFolders } from "services/folders";
+import { getUploadsFolderId } from "services/organizeUploads";
+import { getAllGroups } from "services/groups";
+
+const UploadReuse = ({ reuse, handleChange }) => {
+  const initialGroupList = [{ id: 3, name: "fossy" }];
+  const initialFolderList = [
+    {
+      id: 1,
+      name: "Software Repository",
+      description: "Top Folder",
+      parent: null,
+    },
+  ];
+  const initialUploadList = [
+    {
+      folderId: 1,
+      uploadId: null,
+      uploadName: "",
+      uploadDescription: "",
+    },
+  ];
+  const [reuseData, setReuseData] = useState({
+    groupList: initialGroupList,
+    folderList: initialFolderList,
+    uploadList: initialUploadList,
+    reuseFolder: 1,
+  });
+
+  useEffect(() => {
+    setReuseData((prevData) => ({ ...prevData, groupList: getAllGroups() }));
+  }, []);
+
+  useEffect(() => {
+    getUploadsFolderId(reuseData.reuseFolder, reuse.reuseGroup)
+      .then((res) => {
+        setReuseData((prevData) => ({ ...prevData, uploadList: res }));
+      })
+      .catch(() => {});
+  }, [reuse.reuseGroup]);
+
+  useEffect(() => {
+    getAllFolders(reuse.reuseGroup)
+      .then((res) => {
+        setReuseData((prevData) => ({ ...prevData, folderList: res }));
+      })
+      .catch(() => {});
+  }, [reuse.reuseGroup, reuseData.reuseFolder]);
+
+  const handleReuseDataChange = (e) => {
+    setReuseData((prevData) => ({
+      ...prevData,
+      [e.target.name]: e.target.value,
+    }));
+  };
+
   return (
     <div id="upload-reuse" className="mt-4">
       <p className="font-demi">
         (Optional) Reuse
         <Tooltip title="copy clearing decisions if there is the same file hash between two files" />
       </p>
+      <InputContainer
+        type="select"
+        name="reuseGroup"
+        id="upload-file-reuse-group"
+        onChange={handleChange}
+        options={reuseData.groupList}
+        value={reuse.reuseGroup}
+        property="name"
+        valueProperty="name"
+      >
+        Select the reuse group:
+      </InputContainer>
+      <InputContainer
+        type="select"
+        name="reuseFolder"
+        id="upload-file-reuse-folder"
+        onChange={handleReuseDataChange}
+        options={reuseData.folderList}
+        value={reuseData.reuseFolder}
+        property="name"
+      >
+        Select the reuse folder:
+      </InputContainer>
+      <InputContainer
+        type="select"
+        name="reuseUpload"
+        id="upload-file-reuse-upload"
+        onChange={handleChange}
+        options={reuseData.uploadList}
+        value={parseInt(reuse.reuseUpload, 10)}
+        property="uploadname"
+        valueProperty="id"
+      >
+        Select the reuse upload:
+      </InputContainer>
       <InputContainer
         type="checkbox"
         checked={reuse.reuseEnhanced}
@@ -71,7 +162,7 @@ function UploadReuse({ reuse, handleChange }) {
       </InputContainer>
     </div>
   );
-}
+};
 
 UploadReuse.propTypes = {
   reuse: PropTypes.shape({

--- a/src/components/Upload/CommonFields/UploadReuse/index.jsx
+++ b/src/components/Upload/CommonFields/UploadReuse/index.jsx
@@ -34,7 +34,7 @@ function UploadReuse({ reuse, handleChange }) {
         checked={reuse.reuseEnhanced}
         name="reuseEnhanced"
         id="upload-file-reuse-enhanced"
-        onChange={(e) => handleChange(e)}
+        onChange={handleChange}
       >
         Enhanced reuse (slower)
         <Tooltip title="will copy a clearing decision if the two files differ by one line determined by a diff tool" />
@@ -44,10 +44,30 @@ function UploadReuse({ reuse, handleChange }) {
         checked={reuse.reuseMain}
         name="reuseMain"
         id="upload-file-reuse-main"
-        onChange={(e) => handleChange(e)}
+        onChange={handleChange}
       >
         Reuse main license/s
         <Tooltip title="will copy a main license decision if any" />
+      </InputContainer>
+      <InputContainer
+        type="checkbox"
+        checked={reuse.reuseReport}
+        name="reuseReport"
+        id="upload-file-reuse-report"
+        onChange={handleChange}
+      >
+        Reuse report configuration settings
+        <Tooltip title="use to copy all the information from conf page(if any)" />
+      </InputContainer>
+      <InputContainer
+        type="checkbox"
+        checked={reuse.reuseCopyright}
+        name="reuseCopyright"
+        id="upload-file-reuse-copyright"
+        onChange={handleChange}
+      >
+        Reuse edited and deactivated copyrights
+        <Tooltip title="use to copy edited and deactivated copyrights from the reused package" />
       </InputContainer>
     </div>
   );
@@ -59,6 +79,8 @@ UploadReuse.propTypes = {
     reuseGroup: PropTypes.string.isRequired,
     reuseMain: PropTypes.bool.isRequired,
     reuseEnhanced: PropTypes.bool.isRequired,
+    reuseReport: PropTypes.bool.isRequired,
+    reuseCopyright: PropTypes.bool.isRequired,
   }).isRequired,
   handleChange: PropTypes.func,
 };

--- a/src/components/Upload/CommonFields/UploadReuse/index.jsx
+++ b/src/components/Upload/CommonFields/UploadReuse/index.jsx
@@ -57,17 +57,17 @@ const UploadReuse = ({ reuse, handleChange }) => {
   }, []);
 
   useEffect(() => {
-    getUploadsFolderId(reuseData.reuseFolder, reuse.reuseGroup)
+    getAllFolders(reuse.reuseGroup)
       .then((res) => {
-        setReuseData((prevData) => ({ ...prevData, uploadList: res }));
+        setReuseData((prevData) => ({ ...prevData, folderList: res }));
       })
       .catch(() => {});
   }, [reuse.reuseGroup]);
 
   useEffect(() => {
-    getAllFolders(reuse.reuseGroup)
+    getUploadsFolderId(reuseData.reuseFolder, reuse.reuseGroup)
       .then((res) => {
-        setReuseData((prevData) => ({ ...prevData, folderList: res }));
+        setReuseData((prevData) => ({ ...prevData, uploadList: res }));
       })
       .catch(() => {});
   }, [reuse.reuseGroup, reuseData.reuseFolder]);
@@ -94,6 +94,7 @@ const UploadReuse = ({ reuse, handleChange }) => {
         value={reuse.reuseGroup}
         property="name"
         valueProperty="name"
+        noDataMessage="No Group Found"
       >
         Select the reuse group:
       </InputContainer>
@@ -105,6 +106,7 @@ const UploadReuse = ({ reuse, handleChange }) => {
         options={reuseData.folderList}
         value={reuseData.reuseFolder}
         property="name"
+        noDataMessage="No Folder Found"
       >
         Select the reuse folder:
       </InputContainer>
@@ -117,6 +119,7 @@ const UploadReuse = ({ reuse, handleChange }) => {
         value={parseInt(reuse.reuseUpload, 10)}
         property="uploadname"
         valueProperty="id"
+        noDataMessage="No Uploads Found"
       >
         Select the reuse upload:
       </InputContainer>

--- a/src/components/Upload/CommonFields/index.jsx
+++ b/src/components/Upload/CommonFields/index.jsx
@@ -77,6 +77,8 @@ CommonFields.propTypes = {
     reuseGroup: PropTypes.string.isRequired,
     reuseMain: PropTypes.bool.isRequired,
     reuseEnhanced: PropTypes.bool.isRequired,
+    reuseReport: PropTypes.bool.isRequired,
+    reuseCopyright: PropTypes.bool.isRequired,
   }).isRequired,
   handleChange: PropTypes.func.isRequired,
   handleScanChange: PropTypes.func.isRequired,

--- a/src/components/Widgets/Input/index.jsx
+++ b/src/components/Widgets/Input/index.jsx
@@ -33,6 +33,7 @@ const InputContainer = ({
   options = null,
   multiple = false,
   property,
+  valueProperty,
 }) => {
   if (type === "radio" || type === "checkbox") {
     return (
@@ -75,7 +76,10 @@ const InputContainer = ({
         >
           {options.length > 0 ? (
             options.map((option, index) => (
-              <option key={option.id || index} value={option.id}>
+              <option
+                key={option.id || index}
+                value={valueProperty ? option[valueProperty] : option.id}
+              >
                 {property ? option[property] : option}
               </option>
             ))
@@ -130,6 +134,7 @@ InputContainer.propTypes = {
   ),
   multiple: PropTypes.bool,
   property: PropTypes.string,
+  valueProperty: PropTypes.string,
 };
 
 export default InputContainer;

--- a/src/components/Widgets/Input/index.jsx
+++ b/src/components/Widgets/Input/index.jsx
@@ -34,6 +34,7 @@ const InputContainer = ({
   multiple = false,
   property,
   valueProperty,
+  noDataMessage = "No Data Found",
 }) => {
   if (type === "radio" || type === "checkbox") {
     return (
@@ -85,7 +86,7 @@ const InputContainer = ({
             ))
           ) : (
             <option className="font-demi" disabled>
-              No Data Found
+              {noDataMessage}
             </option>
           )}
         </select>
@@ -135,6 +136,7 @@ InputContainer.propTypes = {
   multiple: PropTypes.bool,
   property: PropTypes.string,
   valueProperty: PropTypes.string,
+  noDataMessage: PropTypes.string,
 };
 
 export default InputContainer;

--- a/src/constants/endpoints.js
+++ b/src/constants/endpoints.js
@@ -57,7 +57,7 @@ const endpoints = {
   },
   organize: {
     uploads: {
-      get: (folder) => `${apiUrl}/uploads?folderId=${folder}`,
+      get: () => `${apiUrl}/uploads`,
       delete: (deleteId) => `${apiUrl}/uploads/${deleteId}`,
       move: (moveId) => `${apiUrl}/uploads/${moveId}`,
       copy: (copyId) => `${apiUrl}/uploads/${copyId}`,

--- a/src/pages/Jobs/ScheduleAgents/index.jsx
+++ b/src/pages/Jobs/ScheduleAgents/index.jsx
@@ -50,7 +50,7 @@ const ScheduleAgents = () => {
     },
     reuse: {
       reuseUpload: 0,
-      reuseGroup: "",
+      reuseGroup: "fossy",
       reuseMain: false,
       reuseEnhanced: false,
       reuseReport: false,

--- a/src/pages/Jobs/ScheduleAgents/index.jsx
+++ b/src/pages/Jobs/ScheduleAgents/index.jsx
@@ -53,6 +53,8 @@ const ScheduleAgents = () => {
       reuseGroup: "",
       reuseMain: false,
       reuseEnhanced: false,
+      reuseReport: false,
+      reuseCopyright: false,
     },
   };
   const initialFolderList = [

--- a/src/pages/Jobs/ScheduleAgents/index.jsx
+++ b/src/pages/Jobs/ScheduleAgents/index.jsx
@@ -157,7 +157,10 @@ const ScheduleAgents = () => {
         ...scanFileData,
         reuse: {
           ...scanFileData.reuse,
-          [e.target.name]: e.target.checked,
+          [e.target.name]:
+            e.target.type === "checkbox"
+              ? e.target.checked
+              : parseInt(e.target.value, 10) || e.target.value,
         },
       });
     }

--- a/src/pages/Upload/File/index.jsx
+++ b/src/pages/Upload/File/index.jsx
@@ -53,7 +53,7 @@ const UploadFile = () => {
     },
     reuse: {
       reuseUpload: 0,
-      reuseGroup: "",
+      reuseGroup: "fossy",
       reuseMain: false,
       reuseEnhanced: false,
       reuseReport: false,
@@ -170,7 +170,10 @@ const UploadFile = () => {
         ...scanFileData,
         reuse: {
           ...scanFileData.reuse,
-          [e.target.name]: e.target.checked,
+          [e.target.name]:
+            e.target.type === "checkbox"
+              ? e.target.checked
+              : parseInt(e.target.value, 10) || e.target.value,
         },
       });
     }

--- a/src/pages/Upload/File/index.jsx
+++ b/src/pages/Upload/File/index.jsx
@@ -56,6 +56,8 @@ const UploadFile = () => {
       reuseGroup: "",
       reuseMain: false,
       reuseEnhanced: false,
+      reuseReport: false,
+      reuseCopyright: false,
     },
   };
   const initialFolderList = [

--- a/src/pages/Upload/Server/index.jsx
+++ b/src/pages/Upload/Server/index.jsx
@@ -50,7 +50,7 @@ const UploadFromServer = () => {
     },
     reuse: {
       reuseUpload: 0,
-      reuseGroup: "",
+      reuseGroup: "fossy",
       reuseMain: false,
       reuseEnhanced: false,
       reuseReport: false,

--- a/src/pages/Upload/Server/index.jsx
+++ b/src/pages/Upload/Server/index.jsx
@@ -53,6 +53,8 @@ const UploadFromServer = () => {
       reuseGroup: "",
       reuseMain: false,
       reuseEnhanced: false,
+      reuseReport: false,
+      reuseCopyright: false,
     },
   };
   const initialFolderList = [

--- a/src/pages/Upload/Server/index.jsx
+++ b/src/pages/Upload/Server/index.jsx
@@ -127,7 +127,10 @@ const UploadFromServer = () => {
         ...scanFileData,
         reuse: {
           ...scanFileData.reuse,
-          [e.target.name]: e.target.checked,
+          [e.target.name]:
+            e.target.type === "checkbox"
+              ? e.target.checked
+              : parseInt(e.target.value, 10) || e.target.value,
         },
       });
     }

--- a/src/pages/Upload/Vcs/index.jsx
+++ b/src/pages/Upload/Vcs/index.jsx
@@ -57,7 +57,7 @@ const UploadFromVcs = () => {
     },
     reuse: {
       reuseUpload: 0,
-      reuseGroup: "",
+      reuseGroup: "fossy",
       reuseMain: false,
       reuseEnhanced: false,
       reuseReport: false,

--- a/src/pages/Upload/Vcs/index.jsx
+++ b/src/pages/Upload/Vcs/index.jsx
@@ -192,7 +192,10 @@ const UploadFromVcs = () => {
         ...scanFileData,
         reuse: {
           ...scanFileData.reuse,
-          [e.target.name]: e.target.checked,
+          [e.target.name]:
+            e.target.type === "checkbox"
+              ? e.target.checked
+              : parseInt(e.target.value, 10) || e.target.value,
         },
       });
     }

--- a/src/pages/Upload/Vcs/index.jsx
+++ b/src/pages/Upload/Vcs/index.jsx
@@ -60,6 +60,8 @@ const UploadFromVcs = () => {
       reuseGroup: "",
       reuseMain: false,
       reuseEnhanced: false,
+      reuseReport: false,
+      reuseCopyright: false,
     },
   };
   const initialFolderList = [

--- a/src/services/folders.js
+++ b/src/services/folders.js
@@ -26,8 +26,8 @@ import {
 } from "api/folders";
 
 // Fetching all the folders
-export const getAllFolders = () => {
-  return getAllFoldersApi().then((res) => {
+export const getAllFolders = (groupName) => {
+  return getAllFoldersApi(groupName).then((res) => {
     return res;
   });
 };

--- a/src/services/organizeUploads.js
+++ b/src/services/organizeUploads.js
@@ -24,8 +24,8 @@ import {
 } from "api/organizeUploads";
 
 // Getting uploads with folder id
-export const getUploadsFolderId = (folderId, groupName) => {
-  return getUploadsByFolderIdApi(folderId, groupName).then((res) => {
+export const getUploadsFolderId = (folderId, groupName, recursive = false) => {
+  return getUploadsByFolderIdApi(folderId, groupName, recursive).then((res) => {
     return res;
   });
 };

--- a/src/services/organizeUploads.js
+++ b/src/services/organizeUploads.js
@@ -24,8 +24,8 @@ import {
 } from "api/organizeUploads";
 
 // Getting uploads with folder id
-export const getUploadsFolderId = (folderId) => {
-  return getUploadsByFolderIdApi(folderId).then((res) => {
+export const getUploadsFolderId = (folderId, groupName) => {
+  return getUploadsByFolderIdApi(folderId, groupName).then((res) => {
     return res;
   });
 };


### PR DESCRIPTION
## Description

Closes #89
Closes #130  

### Changes

- Added `reuse_report` and `reuse_copyright` boolean option
- Created dropdown to select reuse group from the list of accessible groups
- Displayed option to select reuse folder within the selected group (Updates whenever reuse group changes)
- Gave an option to select an upload within the previously selected folder (Updates whenever reuse group or reuse folder changes)
- Fixed prop type check error for `reuse_upload` field. A number was expected but `event.target.value` was returning a string.

## Screenshots
![image](https://user-images.githubusercontent.com/54680709/127294813-15c833ea-0dc0-401e-9a4e-99228238d301.png)

## How to test

Test upload from file page