### PR TITLE
fix(ux): fixed the ux of upload pages

### DIFF
--- a/src/pages/Upload/File/index.jsx
+++ b/src/pages/Upload/File/index.jsx
@@ -89,6 +89,7 @@ const UploadFile = () => {
     setLoading(true);
     createUploadFile(uploadFileData)
       .then((res) => {
+        window.scrollTo({ top: 0 });
         setMessage({
           type: "success",
           text: "Successfully uploaded the files",
@@ -100,6 +101,7 @@ const UploadFile = () => {
           () =>
             scheduleAnalysis(uploadFileData.folderId, uploadId, scanFileData)
               .then(() => {
+                window.scrollTo({ top: 0 });
                 setMessage({
                   type: "success",
                   text: "Analysis for the file is scheduled.",

--- a/src/pages/Upload/Server/index.jsx
+++ b/src/pages/Upload/Server/index.jsx
@@ -136,6 +136,7 @@ const UploadFromServer = () => {
         setFolderList(res);
       })
       .catch((error) => {
+        window.scrollTo({ top: 0 });
         setMessage({
           type: "danger",
           text: error.message,

--- a/src/pages/Upload/Vcs/index.jsx
+++ b/src/pages/Upload/Vcs/index.jsx
@@ -109,6 +109,7 @@ const UploadFromVcs = () => {
     setLoading(true);
     createUploadVcs(uploadVcsData, vcsData)
       .then((res) => {
+        window.scrollTo({ top: 0 });
         setMessage({
           type: "success",
           text: `The Upload has been queued its upload Id is #${res.message}`,
@@ -122,6 +123,7 @@ const UploadFromVcs = () => {
           () =>
             scheduleAnalysis(uploadVcsData.folderId, uploadId, scanFileData)
               .then(() => {
+                window.scrollTo({ top: 0 });
                 setMessage({
                   type: "success",
                   text: "Analysis for the file is scheduled.",

--- a/src/shared/helper.js
+++ b/src/shared/helper.js
@@ -62,6 +62,7 @@ export const getNameInitials = (name) => {
 
 // Common handle error component
 export const handleError = (error, setMessage) => {
+  window.scrollTo({ top: 0 });
   setMessage({
     type: "danger",
     text: error.message,


### PR DESCRIPTION
## Description

fixed the user experience for uploads page since uploads page are longer than one page so on clicking the upload button user have to manually scroll to see the snackbar that whether the file is uploaded or not and we are familiar with the codebase so we knew that scrollbar appears on top right but for the first time user it may be bit confusing.

### Changes

Added the `srollTo({top:0})`

## How to test

Check the uploads pages.

- try uploading any file.
- or try creating any error.