### PR TITLE
feat(API): migrate API from v1 to v2

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,7 +1,7 @@
 # following keys are required
 
 #backend endpoint
-REACT_APP_SERVER_URL=localhost/repo/api/v1
+REACT_APP_SERVER_URL=localhost/repo/api/v2
 
 #for enabling https for backend url
 REACT_APP_HTTPS=false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Build pages
         env:
           PUBLIC_URL: /FOSSologyUI
-          REACT_APP_SERVER_URL: localhost/repo/api/v1
+          REACT_APP_SERVER_URL: localhost/repo/api/v2
           REACT_APP_HTTPS: false
         run:
           yarn build

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Run the following commands inside the project directory.
 ```sh
 docker build \
 -t fossologyui:react1.0 \
---build-arg REACT_APP_SERVER_URL="localhost/repo/api/v1" \
+--build-arg REACT_APP_SERVER_URL="localhost/repo/api/v2" \
 --build-arg REACT_APP_HTTPS="false" .
 ```
 


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/FOSSologyUI/blob/main/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

The [PR #8](https://github.com/Shruti3004/FOSSology-REST-API/pull/8) migrates the API version to v2 hence all subsequent requests in frontend should also be migrated to v2.

### Changes
- Upgrade API versions in all places in UI

## How to test

- Run fossology backend with API version v2
- Update `REACT_APP_SERVER_URL` in `.env` file
- Test if all API calls are made to `localhost/repo/api/v2`