### PR TITLE
feat(browseUploads): added the header and pages

### DIFF
--- a/src/Routes.jsx
+++ b/src/Routes.jsx
@@ -30,6 +30,13 @@ import Home from "pages/Home";
 import Search from "pages/Search";
 import Browse from "pages/Browse";
 
+// Browse Upload pages imports
+import SoftwareHeritage from "pages/BrowseUploads/SoftwareHeritage";
+import LicenseBrowse from "pages/BrowseUploads/LicenseBrowser";
+import FileBrowser from "pages/BrowseUploads/FileBrowser";
+import CopyrightBrowser from "pages/BrowseUploads/Copyright";
+import Ecc from "pages/BrowseUploads/Ecc";
+
 // Help Pages
 import About from "pages/Help/About";
 import Overview from "pages/Help/Overview";
@@ -88,6 +95,29 @@ const Routes = () => {
 
         {/* Browse Page */}
         <PrivateLayout exact path={routes.browse} component={Browse} />
+
+        {/* Browse Uploads Pages */}
+        <PrivateLayout
+          exact
+          path={routes.browseUploads.softwareHeritage}
+          component={SoftwareHeritage}
+        />
+        <PrivateLayout
+          exact
+          path={routes.browseUploads.licenseBrowser}
+          component={LicenseBrowse}
+        />
+        <PrivateLayout
+          exact
+          path={routes.browseUploads.fileBrowser}
+          component={FileBrowser}
+        />
+        <PrivateLayout
+          exact
+          path={routes.browseUploads.copyright}
+          component={CopyrightBrowser}
+        />
+        <PrivateLayout exact path={routes.browseUploads.ecc} component={Ecc} />
 
         {/* Help Pages */}
         <PublicLayout exact path={routes.help.about} component={About} />

--- a/src/components/BrowseUploadsHeader/index.jsx
+++ b/src/components/BrowseUploadsHeader/index.jsx
@@ -21,7 +21,7 @@ import React from "react";
 import { Link, useLocation } from "react-router-dom";
 
 // React Bootstrap Imports
-import { Navbar, Nav } from "react-bootstrap";
+import { Navbar } from "react-bootstrap";
 
 // Routes for all the pages
 import routes from "constants/routes";
@@ -33,66 +33,66 @@ const Header = () => {
   const location = useLocation();
   return (
     <>
-      <Navbar expand="lg" className="py-0 pl-0 mt-3 bg-primary-color">
+      <Navbar expand="lg" className="py-0 pl-0 mt-3 bg-browse-uploads-header">
         <Navbar.Toggle aria-controls="basic-navbar-nav" />
         <Navbar.Collapse id="basic-navbar-nav">
-          <Nav className="ml-auto">
+          <div className="ml-auto py-2">
             {/* Checking whether the user is authenticated */}
             {isAuth() && (
               <>
-                <Nav.Link
-                  as={Link}
+                <Link
                   to={routes.browseUploads.softwareHeritage}
                   className={
-                    location.pathname ===
-                      routes.browseUploads.softwareHeritage && "active-nav-item"
+                    location.pathname === routes.browseUploads.softwareHeritage
+                      ? "active-browse-nav-item browse-uploads-nav-item"
+                      : "browse-uploads-nav-item"
                   }
                 >
                   Software Heritage
-                </Nav.Link>
-                <Nav.Link
-                  as={Link}
+                </Link>
+                <Link
                   to={routes.browseUploads.licenseBrowser}
                   className={
-                    location.pathname === routes.browseUploads.licenseBrowser &&
-                    "active-nav-item"
+                    location.pathname === routes.browseUploads.licenseBrowser
+                      ? "active-browse-nav-item browse-uploads-nav-item"
+                      : "browse-uploads-nav-item"
                   }
                 >
                   License Browser
-                </Nav.Link>
-                <Nav.Link
-                  as={Link}
+                </Link>
+                <Link
                   to={routes.browseUploads.fileBrowser}
                   className={
-                    location.pathname === routes.browseUploads.fileBrowser &&
-                    "active-nav-item"
+                    location.pathname === routes.browseUploads.fileBrowser
+                      ? "active-browse-nav-item browse-uploads-nav-item"
+                      : "browse-uploads-nav-item"
                   }
                 >
                   File Browser
-                </Nav.Link>
-                <Nav.Link
-                  as={Link}
+                </Link>
+                <Link
                   to={routes.browseUploads.copyright}
                   className={
-                    location.pathname === routes.browseUploads.copyright &&
-                    "active-nav-item"
+                    location.pathname === routes.browseUploads.copyright
+                      ? "active-browse-nav-item browse-uploads-nav-item"
+                      : "browse-uploads-nav-item"
                   }
                 >
                   Copyright Browser
-                </Nav.Link>
-                <Nav.Link
-                  as={Link}
+                </Link>
+                <Link
                   to={routes.browseUploads.ecc}
                   className={
-                    location.pathname === routes.browseUploads.ecc &&
-                    "active-nav-item"
+                    location.pathname === routes.browseUploads.ecc
+                      ? "active-browse-nav-item browse-uploads-nav-item"
+                      : "browse-uploads-nav-item"
                   }
                 >
                   ECC
-                </Nav.Link>
+                </Link>
               </>
             )}
-          </Nav>
+          </div>
         </Navbar.Collapse>
       </Navbar>
     </>

--- a/src/components/BrowseUploadsHeader/index.jsx
+++ b/src/components/BrowseUploadsHeader/index.jsx
@@ -1,0 +1,102 @@
+/*
+ Copyright (C) 2021 Shruti Agarwal (mail2shruti.ag@gmail.com)
+
+ SPDX-License-Identifier: GPL-2.0
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+// React Imports
+import React from "react";
+import { Link, useLocation } from "react-router-dom";
+
+// React Bootstrap Imports
+import { Navbar, Nav } from "react-bootstrap";
+
+// Routes for all the pages
+import routes from "constants/routes";
+
+// Helper Functions
+import { isAuth } from "shared/authHelper";
+
+const Header = () => {
+  const location = useLocation();
+  return (
+    <>
+      <Navbar expand="lg" className="py-0 pl-0 mt-3 bg-primary-color">
+        <Navbar.Toggle aria-controls="basic-navbar-nav" />
+        <Navbar.Collapse id="basic-navbar-nav">
+          <Nav className="ml-auto">
+            {/* Checking whether the user is authenticated */}
+            {isAuth() && (
+              <>
+                <Nav.Link
+                  as={Link}
+                  to={routes.browseUploads.softwareHeritage}
+                  className={
+                    location.pathname ===
+                      routes.browseUploads.softwareHeritage && "active-nav-item"
+                  }
+                >
+                  Software Heritage
+                </Nav.Link>
+                <Nav.Link
+                  as={Link}
+                  to={routes.browseUploads.licenseBrowser}
+                  className={
+                    location.pathname === routes.browseUploads.licenseBrowser &&
+                    "active-nav-item"
+                  }
+                >
+                  License Browser
+                </Nav.Link>
+                <Nav.Link
+                  as={Link}
+                  to={routes.browseUploads.fileBrowser}
+                  className={
+                    location.pathname === routes.browseUploads.fileBrowser &&
+                    "active-nav-item"
+                  }
+                >
+                  File Browser
+                </Nav.Link>
+                <Nav.Link
+                  as={Link}
+                  to={routes.browseUploads.copyright}
+                  className={
+                    location.pathname === routes.browseUploads.copyright &&
+                    "active-nav-item"
+                  }
+                >
+                  Copyright Browser
+                </Nav.Link>
+                <Nav.Link
+                  as={Link}
+                  to={routes.browseUploads.ecc}
+                  className={
+                    location.pathname === routes.browseUploads.ecc &&
+                    "active-nav-item"
+                  }
+                >
+                  ECC
+                </Nav.Link>
+              </>
+            )}
+          </Nav>
+        </Navbar.Collapse>
+      </Navbar>
+    </>
+  );
+};
+
+export default Header;

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -77,6 +77,13 @@ const routes = {
       licenseCSV: "/licenseCSV/fossology-license-export.csv",
     },
   },
+  browseUploads: {
+    softwareHeritage: "/browse/softwareHeritage",
+    licenseBrowser: "/browse/licenseBrowser",
+    fileBrowser: "/browse/fileBrowser",
+    copyright: "/browse/copyright",
+    ecc: "/browse/ecc",
+  },
 };
 
 export default routes;

--- a/src/pages/BrowseUploads/Copyright/index.jsx
+++ b/src/pages/BrowseUploads/Copyright/index.jsx
@@ -1,0 +1,34 @@
+/*
+ Copyright (C) 2021 Shruti Agarwal (mail2shruti.ag@gmail.com)
+
+ SPDX-License-Identifier: GPL-2.0
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+import React from "react";
+
+// Title
+import Title from "components/Title";
+
+const CopyrightBrowser = () => {
+  return (
+    <>
+      <Title title="Copyright Browser" />
+
+      <div className="main-container my-3">Copyright Browser</div>
+    </>
+  );
+};
+
+export default CopyrightBrowser;

--- a/src/pages/BrowseUploads/Copyright/index.jsx
+++ b/src/pages/BrowseUploads/Copyright/index.jsx
@@ -21,12 +21,17 @@ import React from "react";
 // Title
 import Title from "components/Title";
 
+// Header
+import BrowseUploadsHeader from "components/BrowseUploadsHeader";
+
 const CopyrightBrowser = () => {
   return (
     <>
       <Title title="Copyright Browser" />
-
-      <div className="main-container my-3">Copyright Browser</div>
+      <div className="main-container my-3">
+        <h1 className="font-size-main-heading">Copyright Browser</h1>
+      </div>
+      <BrowseUploadsHeader />
     </>
   );
 };

--- a/src/pages/BrowseUploads/Ecc/index.jsx
+++ b/src/pages/BrowseUploads/Ecc/index.jsx
@@ -21,12 +21,17 @@ import React from "react";
 // Title
 import Title from "components/Title";
 
+// Header
+import BrowseUploadsHeader from "components/BrowseUploadsHeader";
+
 const Ecc = () => {
   return (
     <>
       <Title title="ECC" />
-
-      <div className="main-container my-3">ECC</div>
+      <div className="main-container my-3">
+        <h1 className="font-size-main-heading">ECC</h1>
+      </div>
+      <BrowseUploadsHeader />
     </>
   );
 };

--- a/src/pages/BrowseUploads/Ecc/index.jsx
+++ b/src/pages/BrowseUploads/Ecc/index.jsx
@@ -1,0 +1,34 @@
+/*
+ Copyright (C) 2021 Shruti Agarwal (mail2shruti.ag@gmail.com)
+
+ SPDX-License-Identifier: GPL-2.0
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+import React from "react";
+
+// Title
+import Title from "components/Title";
+
+const Ecc = () => {
+  return (
+    <>
+      <Title title="ECC" />
+
+      <div className="main-container my-3">ECC</div>
+    </>
+  );
+};
+
+export default Ecc;

--- a/src/pages/BrowseUploads/FileBrowser/index.jsx
+++ b/src/pages/BrowseUploads/FileBrowser/index.jsx
@@ -21,12 +21,17 @@ import React from "react";
 // Title
 import Title from "components/Title";
 
+// Header
+import BrowseUploadsHeader from "components/BrowseUploadsHeader";
+
 const FileBrowser = () => {
   return (
     <>
       <Title title="File Browser" />
-
-      <div className="main-container my-3">File Browser</div>
+      <div className="main-container my-3">
+        <h1 className="font-size-main-heading">File Browser</h1>
+      </div>
+      <BrowseUploadsHeader />
     </>
   );
 };

--- a/src/pages/BrowseUploads/FileBrowser/index.jsx
+++ b/src/pages/BrowseUploads/FileBrowser/index.jsx
@@ -1,0 +1,34 @@
+/*
+ Copyright (C) 2021 Shruti Agarwal (mail2shruti.ag@gmail.com)
+
+ SPDX-License-Identifier: GPL-2.0
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+import React from "react";
+
+// Title
+import Title from "components/Title";
+
+const FileBrowser = () => {
+  return (
+    <>
+      <Title title="File Browser" />
+
+      <div className="main-container my-3">File Browser</div>
+    </>
+  );
+};
+
+export default FileBrowser;

--- a/src/pages/BrowseUploads/LicenseBrowser/index.jsx
+++ b/src/pages/BrowseUploads/LicenseBrowser/index.jsx
@@ -1,0 +1,34 @@
+/*
+ Copyright (C) 2021 Shruti Agarwal (mail2shruti.ag@gmail.com)
+
+ SPDX-License-Identifier: GPL-2.0
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+import React from "react";
+
+// Title
+import Title from "components/Title";
+
+const LicenseBrowser = () => {
+  return (
+    <>
+      <Title title="License Browser" />
+
+      <div className="main-container my-3">License Browser</div>
+    </>
+  );
+};
+
+export default LicenseBrowser;

--- a/src/pages/BrowseUploads/LicenseBrowser/index.jsx
+++ b/src/pages/BrowseUploads/LicenseBrowser/index.jsx
@@ -21,12 +21,17 @@ import React from "react";
 // Title
 import Title from "components/Title";
 
+// Header
+import BrowseUploadsHeader from "components/BrowseUploadsHeader";
+
 const LicenseBrowser = () => {
   return (
     <>
       <Title title="License Browser" />
-
-      <div className="main-container my-3">License Browser</div>
+      <div className="main-container my-3">
+        <h1 className="font-size-main-heading">License Browser</h1>
+      </div>
+      <BrowseUploadsHeader />
     </>
   );
 };

--- a/src/pages/BrowseUploads/SoftwareHeritage/index.jsx
+++ b/src/pages/BrowseUploads/SoftwareHeritage/index.jsx
@@ -1,0 +1,34 @@
+/*
+ Copyright (C) 2021 Shruti Agarwal (mail2shruti.ag@gmail.com)
+
+ SPDX-License-Identifier: GPL-2.0
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+import React from "react";
+
+// Title
+import Title from "components/Title";
+
+const SoftwareHeritage = () => {
+  return (
+    <>
+      <Title title="Software Heritage" />
+
+      <div className="main-container my-3">Software Heritage Details</div>
+    </>
+  );
+};
+
+export default SoftwareHeritage;

--- a/src/pages/BrowseUploads/SoftwareHeritage/index.jsx
+++ b/src/pages/BrowseUploads/SoftwareHeritage/index.jsx
@@ -21,12 +21,17 @@ import React from "react";
 // Title
 import Title from "components/Title";
 
+// Header
+import BrowseUploadsHeader from "components/BrowseUploadsHeader";
+
 const SoftwareHeritage = () => {
   return (
     <>
       <Title title="Software Heritage" />
-
-      <div className="main-container my-3">Software Heritage Details</div>
+      <div className="main-container my-3">
+        <h1 className="font-size-main-heading">Software Heritage Details</h1>
+      </div>
+      <BrowseUploadsHeader />
     </>
   );
 };

--- a/src/styles/globalStyle.js
+++ b/src/styles/globalStyle.js
@@ -57,6 +57,24 @@ const GlobalStyles = createGlobalStyle`
       color: ${({ theme }) => theme.secondaryText};
     }
   }
+  .bg-browse-uploads-header{
+    background: ${({ theme }) => theme.tertiaryColor};
+  }
+  .browse-uploads-nav-item{
+    color: ${({ theme }) => theme.text};
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+    padding: 0.6rem;
+    &:hover{
+      color: ${({ theme }) => theme.text};
+      font-weight: 900;
+      text-decoration: none;
+    }
+  }
+  .active-browse-nav-item{
+    border-bottom: 0.15rem ${({ theme }) => theme.primaryText} solid;
+    font-weight: 900;
+  }
   .dropdown-item{
     color: ${({ theme }) => theme.text};
     &:hover:{

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -24,6 +24,7 @@
 export const lightTheme = {
   primaryColor: "#DC3545",
   secondaryColor: "#A93232",
+  tertiaryColor: "#E5E5E5",
   body: "#FFFFFF",
   text: "#212121",
   primaryText: "#212121",
@@ -35,9 +36,10 @@ export const lightTheme = {
 export const darkTheme = {
   primaryColor: "#525252",
   secondaryColor: "#212121",
+  tertiaryColor: "#E5E5E5",
   body: "#212121",
   text: "#212121",
-  primaryText: "#FFF",
+  primaryText: "#FFFFFF",
   secondaryText: "#FFFFFF",
   toggleBorder: "#6B8096",
   hoverBackgroundColor: "#212121",


### PR DESCRIPTION
## Description

Added the pages fr browseUploads.

### Changes

- Added the pages for browseUploads:
    - Software Heritage
    - License Browser
    - File Browser
    - Copyright
    - ECC
- Added the browse Uploads separate header.

## How to test

Visit to the following routes:
- `/browse/softwareHeritage`
- `/browse/licenseBrowser`
- `/browse/fileBrowser`
- `/browse/copyright`
- `/browse/ecc`



## Screenshots
![Screenshot from 2021-08-06 15-07-44](https://user-images.githubusercontent.com/56133783/128491058-506ad676-2f77-416e-998a-d4c60bf29433.png)
![Screenshot from 2021-08-06 15-07-35](https://user-images.githubusercontent.com/56133783/128491067-9e36f5bb-4762-4944-9929-0a4c64e18563.png)
![Screenshot from 2021-08-06 15-07-31](https://user-images.githubusercontent.com/56133783/128491069-8a8a5016-35d5-486a-abda-69acf2868b9a.png)
![Screenshot from 2021-08-06 15-07-28](https://user-images.githubusercontent.com/56133783/128491072-3227385b-efec-4eef-bdf8-15bc67993241.png)
![Screenshot from 2021-08-06 15-07-24](https://user-images.githubusercontent.com/56133783/128491074-f77ae03e-a042-43bf-acb7-daaa3018e5dc.png)

