### PR TITLE
feat(license-browser): added the license browser page

### DIFF
--- a/src/Routes.jsx
+++ b/src/Routes.jsx
@@ -125,7 +125,7 @@ const Routes = () => {
           />
           <PrivateLayout
             exact
-            path={routes.browseUploads.licenseBrowser}
+            path={`${routes.browseUploads.licenseBrowser}/:uploadID`}
             component={LicenseBrowse}
           />
           <PrivateLayout

--- a/src/Routes.jsx
+++ b/src/Routes.jsx
@@ -125,7 +125,7 @@ const Routes = () => {
           />
           <PrivateLayout
             exact
-            path={`${routes.browseUploads.licenseBrowser}/:uploadID`}
+            path={`${routes.browseUploads.licenseBrowser}/uploadID=:uploadID`}
             component={LicenseBrowse}
           />
           <PrivateLayout

--- a/src/api/upload.js
+++ b/src/api/upload.js
@@ -95,6 +95,30 @@ export const getUploadByIdApi = (uploadId, retries) => {
   });
 };
 
+// Getting a Upload Summary
+export const getUploadSummaryApi = (uploadId) => {
+  const url = endpoints.upload.getSummary(uploadId);
+  return sendRequest({
+    url,
+    method: "GET",
+    headers: {
+      Authorization: getToken(),
+    },
+  });
+};
+
+// Getting a Upload License
+export const getUploadLicenseApi = (uploadId) => {
+  const url = endpoints.upload.getLicense(uploadId);
+  return sendRequest({
+    url,
+    method: "GET",
+    headers: {
+      Authorization: getToken(),
+    },
+  });
+};
+
 createUploadApi.propTypes = {
   folderId: PropTypes.number,
   uploadDescription: PropTypes.string,

--- a/src/api/upload.js
+++ b/src/api/upload.js
@@ -108,13 +108,16 @@ export const getUploadSummaryApi = (uploadId) => {
 };
 
 // Getting a Upload License
-export const getUploadLicenseApi = (uploadId) => {
+export const getUploadLicenseApi = (uploadId, agent) => {
   const url = endpoints.upload.getLicense(uploadId);
   return sendRequest({
     url,
     method: "GET",
     headers: {
       Authorization: getToken(),
+    },
+    queryParams: {
+      agent,
     },
   });
 };

--- a/src/components/BrowseUploadsHeader/index.jsx
+++ b/src/components/BrowseUploadsHeader/index.jsx
@@ -51,9 +51,11 @@ const Header = () => {
                   Software Heritage
                 </Link>
                 <Link
-                  to={routes.browseUploads.licenseBrowser}
+                  to={`${routes.browseUploads.licenseBrowser}/:uploadID`}
                   className={
-                    location.pathname === routes.browseUploads.licenseBrowser
+                    location.pathname.includes(
+                      routes.browseUploads.licenseBrowser
+                    )
                       ? "active-browse-nav-item browse-uploads-nav-item"
                       : "browse-uploads-nav-item"
                   }

--- a/src/components/BrowseUploadsHeader/index.jsx
+++ b/src/components/BrowseUploadsHeader/index.jsx
@@ -51,7 +51,7 @@ const Header = () => {
                   Software Heritage
                 </Link>
                 <Link
-                  to={`${routes.browseUploads.licenseBrowser}/:uploadID`}
+                  to={`${routes.browseUploads.licenseBrowser}/uploadID=:uploadID`}
                   className={
                     location.pathname.includes(
                       routes.browseUploads.licenseBrowser

--- a/src/constants/endpoints.js
+++ b/src/constants/endpoints.js
@@ -53,6 +53,8 @@ const endpoints = {
   upload: {
     uploadCreate: () => `${apiUrl}/uploads`,
     getId: (uploadId) => `${apiUrl}/uploads/${uploadId}`,
+    getSummary: (uploadId) => `${apiUrl}/uploads/${uploadId}/summary`,
+    getLicense: (uploadId) => `${apiUrl}/uploads/${uploadId}/licenses`,
   },
   browse: {
     get: () => `${apiUrl}/uploads`,

--- a/src/pages/Browse/index.jsx
+++ b/src/pages/Browse/index.jsx
@@ -283,6 +283,7 @@ const Browse = () => {
                 </tr>
               </thead>
               <tbody>
+<<<<<<< HEAD
                 {browseDataList
                   ?.filter((post) => {
                     if (query === "") {
@@ -302,6 +303,19 @@ const Browse = () => {
                         <div className="font-demi">{data?.uploadname}</div>
                         <div className="font-size-small">
                           {data?.description}
+=======
+                {browseDataList?.map((data) => (
+                  <tr key={data?.id} className="text-center">
+                    <td>
+                      <Link
+                        to={`${routes.browseUploads.licenseBrowser}/${data.id}`}
+                      >
+                        <div className="text-primary-color">
+                          <div className="font-demi">{data?.uploadname}</div>
+                          <div className="font-size-small">
+                            {data?.description}
+                          </div>
+>>>>>>> fix(route): fixed the route of license browser
                         </div>
                         <InputContainer
                           name="action"

--- a/src/pages/Browse/index.jsx
+++ b/src/pages/Browse/index.jsx
@@ -18,6 +18,8 @@
 */
 
 import React, { useState, useEffect } from "react";
+import routes from "constants/routes";
+import { Link } from "react-router-dom";
 import arrayToTree from "array-to-tree";
 import messages from "constants/messages";
 

--- a/src/pages/Browse/index.jsx
+++ b/src/pages/Browse/index.jsx
@@ -283,7 +283,6 @@ const Browse = () => {
                 </tr>
               </thead>
               <tbody>
-<<<<<<< HEAD
                 {browseDataList
                   ?.filter((post) => {
                     if (query === "") {
@@ -300,23 +299,16 @@ const Browse = () => {
                   ?.map((data) => (
                     <tr key={data?.id} className="text-center">
                       <td>
-                        <div className="font-demi">{data?.uploadname}</div>
-                        <div className="font-size-small">
-                          {data?.description}
-=======
-                {browseDataList?.map((data) => (
-                  <tr key={data?.id} className="text-center">
-                    <td>
-                      <Link
-                        to={`${routes.browseUploads.licenseBrowser}/${data.id}`}
-                      >
-                        <div className="text-primary-color">
-                          <div className="font-demi">{data?.uploadname}</div>
-                          <div className="font-size-small">
-                            {data?.description}
+                        <Link
+                          to={`${routes.browseUploads.licenseBrowser}/uploadID=${data.id}`}
+                        >
+                          <div className="text-primary-color">
+                            <div className="font-demi">{data?.uploadname}</div>
+                            <div className="font-size-small">
+                              {data?.description}
+                            </div>
                           </div>
->>>>>>> fix(route): fixed the route of license browser
-                        </div>
+                        </Link>
                         <InputContainer
                           name="action"
                           type="select"
@@ -350,7 +342,7 @@ const Browse = () => {
                       <td>{data?.uploaddate.split(".")[0]}</td>
                     </tr>
                   ))}
-                <tr className="text-left">
+                <tr>
                   <td colSpan="6">
                     <div className="right-pagination">
                       Page:

--- a/src/pages/BrowseUploads/LicenseBrowser/index.jsx
+++ b/src/pages/BrowseUploads/LicenseBrowser/index.jsx
@@ -16,24 +16,160 @@
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-import React from "react";
+import React, { useState, useEffect } from "react";
+import queryString from "query-string";
+import PropTypes from "prop-types";
 
 // Title
 import Title from "components/Title";
 
+// Widgets
+import { Alert } from "components/Widgets";
+
 // Header
 import BrowseUploadsHeader from "components/BrowseUploadsHeader";
 
-const LicenseBrowser = () => {
+// Required functions for calling APIs
+import { getUploadSummary } from "services/upload";
+
+// Helper function for error handling
+import { handleError } from "shared/helper";
+
+const LicenseBrowser = ({ location }) => {
+  // Setting the upload Id
+  const [uploadId, setuploadId] = useState();
+
+  // Setting the browse data to the table
+  const [summaryData, setSummaryData] = useState();
+
+  // State Variables for handling Error Boundaries
+  // const [loading, setLoading] = useState(false);
+  const [showMessage, setShowMessage] = useState(false);
+  const [message, setMessage] = useState();
+
+  useEffect(() => {
+    setMessage({
+      type: "success",
+      text: "Loading...",
+    });
+    setShowMessage(true);
+    const queryParams = queryString.parse(location.search);
+    const { uploadID } = queryParams;
+    if (uploadID) {
+      setuploadId(uploadID);
+    }
+    if (uploadId) {
+      getUploadSummary(uploadId)
+        .then((res) => {
+          setSummaryData(res);
+          setShowMessage(false);
+        })
+        .catch((error) => {
+          handleError(error, setMessage);
+          setShowMessage(true);
+        });
+      // getUploadLicense(uploadId)
+      //   .then((res) => {
+      //     console.log(res);
+      //     setShowMessage(false);
+      //   })
+      //   .catch((error) => {
+      //     handleError(error, setMessage);
+      //     setShowMessage(true);
+      //   });
+    } else {
+      setMessage({
+        type: "danger",
+        text: "UploadId should be an integer",
+      });
+    }
+  }, [uploadId]);
+
   return (
     <>
       <Title title="License Browser" />
       <div className="main-container my-3">
+        {showMessage && (
+          <Alert
+            type={message.type}
+            setShow={setShowMessage}
+            message={message.text}
+          />
+        )}
         <h1 className="font-size-main-heading">License Browser</h1>
       </div>
       <BrowseUploadsHeader />
+      <div className="main-container my-4">
+        <div className="row">
+          <div className="col-12 col-lg-8 col-xl-9">
+            <table className="table table-striped text-primary-color font-size-medium table-responsive-sm table-bordered">
+              <thead>
+                <tr className="font-bold text-center font-size-sub-heading">
+                  <th>Files</th>
+                  <th>Scanner Results</th>
+                  <th>Edited Results</th>
+                  <th>Clearing Status</th>
+                  <th>Cleared/ Open/ Total</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr className="text-center">
+                  <td>-</td>
+                  <td>-</td>
+                  <td>-</td>
+                  <td>-</td>
+                  <td>-</td>
+                  <td>-</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div className="col-12 col-lg-4 col-xl-3">
+            {summaryData && (
+              <>
+                <h4 className="font-bold font-size-sub-heading">Summary</h4>
+                <table className="table table-bordered mt-3">
+                  <tbody>
+                    <tr>
+                      <td>Main License</td>
+                      <td>{summaryData.mainLicense}</td>
+                    </tr>
+                    <tr>
+                      <td>Unique Licenses</td>
+                      <td>{summaryData.uniqueLicenses}</td>
+                    </tr>
+                    <tr>
+                      <td>Unique Concluded Licenses</td>
+                      <td>{summaryData.uniqueConcludedLicenses}</td>
+                    </tr>
+                    <tr>
+                      <td>Total Concluded Licenses</td>
+                      <td>{summaryData.totalConcludedLicenses}</td>
+                    </tr>
+                    <tr>
+                      <td>Files Cleared</td>
+                      <td>{summaryData.filesCleared}</td>
+                    </tr>
+                    <tr>
+                      <td>Copyright Count</td>
+                      <td>{summaryData.copyrightCount}</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
     </>
   );
+};
+
+LicenseBrowser.propTypes = {
+  location: PropTypes.shape({
+    search: PropTypes.string,
+  }),
 };
 
 export default LicenseBrowser;

--- a/src/pages/BrowseUploads/LicenseBrowser/index.jsx
+++ b/src/pages/BrowseUploads/LicenseBrowser/index.jsx
@@ -17,8 +17,7 @@
 */
 
 import React, { useState, useEffect } from "react";
-import queryString from "query-string";
-import PropTypes from "prop-types";
+import { useParams } from "react-router-dom";
 
 // Title
 import Title from "components/Title";
@@ -35,7 +34,7 @@ import { getUploadSummary } from "services/upload";
 // Helper function for error handling
 import { handleError } from "shared/helper";
 
-const LicenseBrowser = ({ location }) => {
+const LicenseBrowser = () => {
   // Setting the upload Id
   const [uploadId, setuploadId] = useState();
 
@@ -47,14 +46,14 @@ const LicenseBrowser = ({ location }) => {
   const [showMessage, setShowMessage] = useState(false);
   const [message, setMessage] = useState();
 
+  // Getting a upload Id
+  const { uploadID } = useParams();
   useEffect(() => {
     setMessage({
       type: "success",
       text: "Loading...",
     });
     setShowMessage(true);
-    const queryParams = queryString.parse(location.search);
-    const { uploadID } = queryParams;
     if (uploadID) {
       setuploadId(uploadID);
     }
@@ -164,12 +163,6 @@ const LicenseBrowser = ({ location }) => {
       </div>
     </>
   );
-};
-
-LicenseBrowser.propTypes = {
-  location: PropTypes.shape({
-    search: PropTypes.string,
-  }),
 };
 
 export default LicenseBrowser;

--- a/src/pages/BrowseUploads/LicenseBrowser/index.jsx
+++ b/src/pages/BrowseUploads/LicenseBrowser/index.jsx
@@ -29,7 +29,7 @@ import { Alert } from "components/Widgets";
 import BrowseUploadsHeader from "components/BrowseUploadsHeader";
 
 // Required functions for calling APIs
-import { getUploadSummary } from "services/upload";
+import { getUploadSummary, getUploadLicense } from "services/upload";
 
 // Helper function for error handling
 import { handleError } from "shared/helper";
@@ -41,8 +41,10 @@ const LicenseBrowser = () => {
   // Setting the browse data to the table
   const [summaryData, setSummaryData] = useState();
 
+  // Setting the browse data to the table
+  const [filesData, setFilesData] = useState();
+
   // State Variables for handling Error Boundaries
-  // const [loading, setLoading] = useState(false);
   const [showMessage, setShowMessage] = useState(false);
   const [message, setMessage] = useState();
 
@@ -67,15 +69,15 @@ const LicenseBrowser = () => {
           handleError(error, setMessage);
           setShowMessage(true);
         });
-      // getUploadLicense(uploadId)
-      //   .then((res) => {
-      //     console.log(res);
-      //     setShowMessage(false);
-      //   })
-      //   .catch((error) => {
-      //     handleError(error, setMessage);
-      //     setShowMessage(true);
-      //   });
+      getUploadLicense(uploadId, ["ojo", "nomos", "monk"])
+        .then((res) => {
+          setFilesData(res);
+          setShowMessage(false);
+        })
+        .catch((error) => {
+          handleError(error, setMessage);
+          setShowMessage(true);
+        });
     } else {
       setMessage({
         type: "danger",
@@ -100,10 +102,10 @@ const LicenseBrowser = () => {
       <BrowseUploadsHeader />
       <div className="main-container my-4">
         <div className="row">
-          <div className="col-12 col-lg-8 col-xl-9">
-            <table className="table table-striped text-primary-color font-size-medium table-responsive-sm table-bordered">
+          <div className="col-12 col-lg-12 col-xl-9">
+            <table className="table table-striped text-primary-color font-size-medium table-responsive table-bordered">
               <thead>
-                <tr className="font-bold text-center font-size-sub-heading">
+                <tr className="font-bold font-size-sub-heading">
                   <th>Files</th>
                   <th>Scanner Results</th>
                   <th>Edited Results</th>
@@ -113,22 +115,34 @@ const LicenseBrowser = () => {
                 </tr>
               </thead>
               <tbody>
-                <tr className="text-center">
-                  <td>-</td>
-                  <td>-</td>
-                  <td>-</td>
-                  <td>-</td>
-                  <td>-</td>
-                  <td>-</td>
-                </tr>
+                {filesData &&
+                  filesData.length > 0 &&
+                  filesData.map((data, index) => (
+                    <>
+                      {index < 10 ? (
+                        <tr key={data.id}>
+                          <td>{data.filePath}</td>
+                          <td>{data.findings.scanner}</td>
+                          <td>-</td>
+                          <td>-</td>
+                          <td>-</td>
+                          <td>-</td>
+                        </tr>
+                      ) : (
+                        ""
+                      )}
+                    </>
+                  ))}
               </tbody>
             </table>
           </div>
-          <div className="col-12 col-lg-4 col-xl-3">
+          <div className="col-12 col-lg-12 col-xl-3">
             {summaryData && (
               <>
-                <h4 className="font-bold font-size-sub-heading">Summary</h4>
-                <table className="table table-bordered mt-3">
+                <h4 className="font-bold font-size-sub-heading text-primary-color">
+                  Summary
+                </h4>
+                <table className="table table-bordered text-primary-color mt-3">
                   <tbody>
                     <tr>
                       <td>Main License</td>

--- a/src/services/upload.js
+++ b/src/services/upload.js
@@ -1,8 +1,6 @@
 /*
  Copyright (C) 2021 Shruti Agarwal (mail2shruti.ag@gmail.com), Aman Dwivedi (aman.dwivedi5@gmail.com)
-
  SPDX-License-Identifier: GPL-2.0
-
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
  version 2 as published by the Free Software Foundation.
@@ -10,7 +8,6 @@
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
-
  You should have received a copy of the GNU General Public License along
  with this program; if not, write to the Free Software Foundation, Inc.,
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
@@ -21,6 +18,8 @@ import {
   getUploadByIdApi,
   createUploadVcsApi,
   createUploadUrlApi,
+  getUploadSummaryApi,
+  getUploadLicenseApi,
 } from "api/upload";
 
 // Create Uploads from File
@@ -59,6 +58,20 @@ export const createUploadUrl = (header, body) => {
 // Getting a Upload by id
 export const getUploadById = (uploadId, retries) => {
   return getUploadByIdApi(uploadId, retries).then((res) => {
+    return res;
+  });
+};
+
+// Getting a Upload Summary
+export const getUploadSummary = (uploadId) => {
+  return getUploadSummaryApi(uploadId).then((res) => {
+    return res;
+  });
+};
+
+// Getting a Upload License
+export const getUploadLicense = (uploadId, agent) => {
+  return getUploadLicenseApi(uploadId, agent).then((res) => {
     return res;
   });
 };


### PR DESCRIPTION
## Description

Added the License Browser page.

### Changes

- Added the license prowser page.
- Added the api endpoints for summary and license of the uploads.
- Integrated the api for uploads summary api.
- Completed the function for getting license in api and services.
- called the function in license browser page.

## How to test

Visit to `/browse` and click to any of the uploads.

## Screenshots
![Screenshot from 2021-08-09 15-45-13](https://user-images.githubusercontent.com/56133783/128708182-8882f902-5585-41d3-a441-cf3642938a10.png)
![Screenshot from 2021-08-11 06-29-16](https://user-images.githubusercontent.com/56133783/128954980-5c8304fc-4428-45c3-aac8-456847a4797c.png)
![Screenshot from 2021-08-11 06-28-02](https://user-images.githubusercontent.com/56133783/128954986-07e751a3-6e1c-4756-9b0e-f57441e8f770.png)
