### PR TITLE
test(api): add tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-prettier": "^3.4.0",
     "eslint-plugin-react-hooks": "^1.7.0",
+    "jest-fetch-mock": "3.0.3",
     "prettier": "^2.3.1"
   }
 }

--- a/src/api/auth.test.js
+++ b/src/api/auth.test.js
@@ -1,0 +1,50 @@
+/*
+ Copyright (C) 2021 Edgar Sherman (edgarshermangh14@gmail.com)
+ SPDX-License-Identifier: GPL-2.0
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+import sendRequest from "api/sendRequest";
+import fetchTokenApi from "api/auth";
+import { tokenExpiryDays, tokenScope } from "constants/auth";
+import * as helper from "shared/helper";
+import { getDate } from "shared/helper";
+import endpoints from "constants/endpoints";
+
+jest.mock("api/sendRequest");
+
+describe("auth", () => {
+  test("fetchTokenApi", () => {
+    const username = "user";
+    const password = "pass";
+    const randomString = "random";
+    sendRequest.mockImplementation(() => true);
+    jest.spyOn(helper, "randomString");
+    helper.randomString.mockReturnValue(randomString);
+
+    expect(fetchTokenApi(username, password)).toBe(sendRequest({}));
+    expect(sendRequest).toBeCalledWith(
+      expect.objectContaining({
+        url: endpoints.auth.tokens(),
+        method: "POST",
+        body: {
+          username,
+          password,
+          token_name: randomString,
+          token_scope: tokenScope,
+          token_expire: getDate(tokenExpiryDays),
+        },
+        addGroupName: false,
+      })
+    );
+  });
+});

--- a/src/api/browse.test.js
+++ b/src/api/browse.test.js
@@ -1,0 +1,51 @@
+/*
+ Copyright (C) 2021 Edgar Sherman (edgarshermangh14@gmail.com)
+ SPDX-License-Identifier: GPL-2.0
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+import sendRequest from "api/sendRequest";
+import getBrowseDataApi from "api/browse";
+import { getToken } from "shared/authHelper";
+import endpoints from "constants/endpoints";
+
+jest.mock("api/sendRequest");
+
+describe("browse", () => {
+  test("getBrowseDataApi", () => {
+    const props = {
+      page: 1,
+      limit: 2,
+      folderId: 3,
+      recursive: true,
+    };
+    const url = endpoints.browse.get();
+    sendRequest.mockImplementation(() => true);
+
+    expect(getBrowseDataApi(props)).toBe(sendRequest({}));
+    expect(sendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url,
+        method: "GET",
+        headers: {
+          Authorization: getToken(),
+          page: props.page,
+          limit: props.limit,
+        },
+        queryParams: {
+          folderId: props.folderId,
+          recursive: props.recursive,
+        },
+      })
+    );
+  });
+});

--- a/src/api/folders.test.js
+++ b/src/api/folders.test.js
@@ -1,0 +1,148 @@
+/*
+ Copyright (C) 2021 Edgar Sherman (edgarshermangh14@gmail.com)
+ SPDX-License-Identifier: GPL-2.0
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+import sendRequest from "api/sendRequest";
+import {
+  createFolderApi,
+  deleteFolderApi,
+  editFolderApi,
+  getAllFoldersApi,
+  getSingleFolderApi,
+  moveCopyFolderApi,
+} from "api/folders";
+import { getToken } from "shared/authHelper";
+import endpoints from "constants/endpoints";
+
+jest.mock("api/sendRequest");
+
+describe("folders", () => {
+  test("getAllFoldersApi", () => {
+    const groupName = "group";
+    const url = endpoints.folders.getAll();
+    sendRequest.mockImplementation(() => true);
+
+    expect(getAllFoldersApi(groupName)).toBe(sendRequest({}));
+    expect(sendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url,
+        method: "GET",
+        headers: {
+          Authorization: getToken(),
+        },
+        groupName,
+      })
+    );
+  });
+
+  test("getSingleFolderAPI", () => {
+    const id = 1;
+    const url = endpoints.folders.getSingle(id);
+    sendRequest.mockImplementation(() => true);
+
+    expect(getSingleFolderApi(id)).toBe(sendRequest({}));
+    expect(sendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url,
+        method: "GET",
+        headers: {
+          Authorization: getToken(),
+        },
+      })
+    );
+  });
+
+  test("deleteFolderApi", () => {
+    const id = 1;
+    const url = endpoints.folders.getSingle(id);
+    sendRequest.mockImplementation(() => true);
+
+    expect(deleteFolderApi(id)).toBe(sendRequest({}));
+    expect(sendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url,
+        method: "DELETE",
+        headers: {
+          Authorization: getToken(),
+        },
+      })
+    );
+  });
+
+  test("createFolderApi", () => {
+    const parentFolder = "parent";
+    const folderName = "name";
+    const folderDescription = "description";
+    const url = endpoints.folders.create();
+    sendRequest.mockImplementation(() => true);
+
+    expect(createFolderApi(parentFolder, folderName, folderDescription)).toBe(
+      sendRequest({})
+    );
+    expect(sendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url,
+        method: "POST",
+        headers: {
+          Authorization: getToken(),
+          parentFolder,
+          folderName,
+          folderDescription,
+        },
+      })
+    );
+  });
+
+  test("editFolderApi", () => {
+    const name = "name";
+    const description = "description";
+    const id = 1;
+    const url = endpoints.folders.edit(id);
+    sendRequest.mockImplementation(() => true);
+
+    expect(editFolderApi(name, description, id)).toBe(sendRequest({}));
+    expect(sendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url,
+        method: "PATCH",
+        headers: {
+          Authorization: getToken(),
+          name,
+          description,
+        },
+      })
+    );
+  });
+
+  test("moveCopyFolderApi", () => {
+    const parent = "parent";
+    const id = 1;
+    const action = "action";
+    const url = endpoints.folders.move(id);
+    sendRequest.mockImplementation(() => true);
+
+    expect(moveCopyFolderApi(parent, id, action)).toBe(sendRequest({}));
+    expect(sendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url,
+        method: "PUT",
+        headers: {
+          Authorization: getToken(),
+          parent,
+          action,
+        },
+      })
+    );
+  });
+});

--- a/src/api/groups.test.js
+++ b/src/api/groups.test.js
@@ -1,0 +1,59 @@
+/*
+ Copyright (C) 2021 Edgar Sherman (edgarshermangh14@gmail.com)
+ SPDX-License-Identifier: GPL-2.0
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+import sendRequest from "api/sendRequest";
+import endpoints from "constants/endpoints";
+import { createGroupApi, getAllGroupsApi } from "api/groups";
+import { getToken } from "shared/authHelper";
+
+jest.mock("api/sendRequest");
+
+describe("groups", () => {
+  test("getAllGroupsApi", () => {
+    const url = endpoints.admin.groups.getAll();
+    sendRequest.mockImplementation(() => true);
+
+    expect(getAllGroupsApi()).toBe(sendRequest({}));
+    expect(sendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url,
+        method: "GET",
+        headers: {
+          Authorization: getToken(),
+        },
+        addGroupName: false,
+      })
+    );
+  });
+
+  test("createGroupApi", () => {
+    const name = "name";
+    const url = endpoints.admin.groups.create();
+    sendRequest.mockImplementation(() => true);
+
+    expect(createGroupApi(name)).toBe(sendRequest({}));
+    expect(sendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url,
+        method: "POST",
+        headers: {
+          Authorization: getToken(),
+          name,
+        },
+        addGroupName: false,
+      })
+    );
+  });
+});

--- a/src/api/info.test.js
+++ b/src/api/info.test.js
@@ -1,0 +1,48 @@
+/*
+ Copyright (C) 2021 Edgar Sherman (edgarshermangh14@gmail.com)
+ SPDX-License-Identifier: GPL-2.0
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+import sendRequest from "api/sendRequest";
+import endpoints from "constants/endpoints";
+import { getHealthApi, getInfoApi } from "api/info";
+
+jest.mock("api/sendRequest");
+
+describe("info", () => {
+  test("getInfoApi", () => {
+    const url = endpoints.info.info();
+    sendRequest.mockImplementation(() => true);
+
+    expect(getInfoApi()).toBe(sendRequest({}));
+    expect(sendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url,
+        method: "GET",
+      })
+    );
+  });
+
+  test("getHealthApi", () => {
+    const url = endpoints.info.health();
+    sendRequest.mockImplementation(() => true);
+
+    expect(getHealthApi()).toBe(sendRequest({}));
+    expect(sendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url,
+        method: "GET",
+      })
+    );
+  });
+});

--- a/src/api/jobs.test.js
+++ b/src/api/jobs.test.js
@@ -1,0 +1,156 @@
+/*
+ Copyright (C) 2021 Edgar Sherman (edgarshermangh14@gmail.com)
+ SPDX-License-Identifier: GPL-2.0
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+import sendRequest from "api/sendRequest";
+import endpoints from "constants/endpoints";
+import {
+  downloadReportApi,
+  getJobApi,
+  scheduleAnalysisApi,
+  scheduleReportApi,
+} from "api/jobs";
+import { getToken } from "shared/authHelper";
+
+jest.mock("api/sendRequest");
+
+describe("jobs", () => {
+  test("getJobApi", () => {
+    const jobId = 1;
+    const url = endpoints.jobs.details(jobId);
+    sendRequest.mockImplementation(() => true);
+
+    expect(getJobApi({ jobId })).toBe(sendRequest({}));
+    expect(sendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url,
+        method: "GET",
+      })
+    );
+  });
+
+  test("scheduleAnalysisApi", () => {
+    const folderId = 1;
+    const uploadId = 2;
+    const scanData = {
+      analysis: {
+        bucket: "bucket",
+        copyrightEmailAuthor: "copyrightEmailAuthor",
+        ecc: "ecc",
+        keyword: "keyword",
+        mime: "mime",
+        monk: "monk",
+        nomos: "nomos",
+        ojo: "ojo",
+        package: "package",
+      },
+      decider: {
+        nomosMonk: "nomosMonk",
+        bulkReused: "bulkReused",
+        newScanner: "newScanner",
+        ojoDecider: "ojoDecider",
+      },
+      reuse: {
+        reuseUpload: "reuseUpload",
+        reuseGroup: "reuseGroup",
+        reuseMain: "reuseMain",
+        reuseEnhanced: "reuseEnhanced",
+        reuseReport: "reuseReport",
+        reuseCopyright: "reuseCopyright",
+      },
+    };
+    const url = endpoints.jobs.scheduleAnalysis();
+    sendRequest.mockImplementation(() => true);
+
+    expect(scheduleAnalysisApi(folderId, uploadId, scanData)).toBe(
+      sendRequest({})
+    );
+    expect(sendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url,
+        method: "POST",
+        headers: {
+          Authorization: getToken(),
+          folderId,
+          uploadId,
+        },
+        body: {
+          analysis: {
+            bucket: scanData.analysis.bucket,
+            copyright_email_author: scanData.analysis.copyrightEmailAuthor,
+            ecc: scanData.analysis.ecc,
+            keyword: scanData.analysis.keyword,
+            mime: scanData.analysis.mime,
+            monk: scanData.analysis.monk,
+            nomos: scanData.analysis.nomos,
+            ojo: scanData.analysis.ojo,
+            package: scanData.analysis.package,
+          },
+          decider: {
+            nomos_monk: scanData.decider.nomosMonk,
+            bulk_reused: scanData.decider.bulkReused,
+            new_scanner: scanData.decider.newScanner,
+            ojo_decider: scanData.decider.ojoDecider,
+          },
+          reuse: {
+            reuse_upload: scanData.reuse.reuseUpload,
+            reuse_group: scanData.reuse.reuseGroup,
+            reuse_main: scanData.reuse.reuseMain,
+            reuse_enhanced: scanData.reuse.reuseEnhanced,
+            reuse_report: scanData.reuse.reuseReport,
+            reuse_copyright: scanData.reuse.reuseCopyright,
+          },
+        },
+      })
+    );
+  });
+
+  test("scheduleReportApi", () => {
+    const uploadId = 1;
+    const reportFormat = "reportFormat";
+    const url = endpoints.jobs.scheduleReport();
+    sendRequest.mockImplementation(() => true);
+
+    expect(scheduleReportApi(uploadId, reportFormat)).toBe(sendRequest({}));
+    expect(sendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url,
+        method: "GET",
+        headers: {
+          Authorization: getToken(),
+          uploadId,
+          reportFormat,
+        },
+      })
+    );
+  });
+
+  test("downloadReportApi", () => {
+    const reportId = 1;
+    const url = endpoints.jobs.downloadReport(reportId);
+    sendRequest.mockImplementation(() => true);
+
+    expect(downloadReportApi(reportId)).toBe(sendRequest({}));
+    expect(sendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url,
+        method: "GET",
+        headers: {
+          Authorization: getToken(),
+        },
+        isFile: true,
+      })
+    );
+  });
+});

--- a/src/api/licenses.test.js
+++ b/src/api/licenses.test.js
@@ -1,0 +1,87 @@
+/*
+ Copyright (C) 2021 Edgar Sherman (edgarshermangh14@gmail.com)
+ SPDX-License-Identifier: GPL-2.0
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+import sendRequest from "api/sendRequest";
+import endpoints from "constants/endpoints";
+import { getToken } from "shared/authHelper";
+import { createCandidateLicenseApi, getAllLicenseApi } from "api/licenses";
+
+jest.mock("api/sendRequest");
+
+describe("licenses", () => {
+  test("getAllLicenseApi", () => {
+    const page = 1;
+    const limit = 2;
+    const kind = "kind";
+    const url = endpoints.license.get();
+
+    sendRequest.mockImplementation(() => true);
+
+    expect(getAllLicenseApi({ page, limit, kind })).toBe(sendRequest({}));
+    expect(sendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url,
+        method: "GET",
+        headers: {
+          Authorization: getToken(),
+          page,
+          limit,
+        },
+        queryParams: {
+          kind,
+        },
+      })
+    );
+  });
+
+  test("createCandidateLicenseApi", () => {
+    const shortName = "shortName";
+    const fullName = "fullName";
+    const text = "text";
+    const risk = "risk";
+    const licenseUrl = "licenseUrl";
+    const mergeRequest = "mergeRequest";
+    const url = endpoints.license.createCandidateLicense();
+
+    expect(
+      createCandidateLicenseApi({
+        shortName,
+        fullName,
+        text,
+        risk,
+        licenseUrl,
+        mergeRequest,
+      })
+    ).toBe(sendRequest({}));
+    expect(sendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url,
+        method: "POST",
+        headers: {
+          Authorization: getToken(),
+        },
+        body: {
+          shortName,
+          fullName,
+          text,
+          risk,
+          url: licenseUrl,
+          isCandidate: true,
+          mergeRequest,
+        },
+      })
+    );
+  });
+});

--- a/src/api/organizeUploads.test.js
+++ b/src/api/organizeUploads.test.js
@@ -1,0 +1,117 @@
+/*
+ Copyright (C) 2021 Edgar Sherman (edgarshermangh14@gmail.com)
+ SPDX-License-Identifier: GPL-2.0
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+import sendRequest from "api/sendRequest";
+import endpoints from "constants/endpoints";
+import { getToken } from "shared/authHelper";
+import {
+  copyUploadApi,
+  deleteUploadsApi,
+  getUploadsByFolderIdApi,
+  moveUploadApi,
+} from "api/organizeUploads";
+
+jest.mock("api/sendRequest");
+
+describe("organizeUploads", () => {
+  test("getUploadsByFolderIdApi", () => {
+    const id = 1;
+    const groupName = "groupName";
+    const recursive = "recursive";
+    const url = endpoints.organize.uploads.get();
+    sendRequest.mockImplementation(() => true);
+
+    expect(getUploadsByFolderIdApi(id, groupName, recursive)).toBe(
+      sendRequest({})
+    );
+    expect(sendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url,
+        method: "GET",
+        headers: {
+          Authorization: getToken(),
+        },
+        groupName,
+        queryParams: {
+          recursive,
+          folderId: id,
+        },
+      })
+    );
+  });
+
+  test("deleteUploadsApi", () => {
+    const id = 1;
+    const url = endpoints.organize.uploads.delete(id);
+    sendRequest.mockImplementation(() => true);
+
+    expect(deleteUploadsApi(id)).toBe(sendRequest({}));
+    expect(sendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url,
+        method: "DELETE",
+        headers: {
+          Authorization: getToken(),
+        },
+      })
+    );
+  });
+
+  test("moveUploadApi", () => {
+    const folderId = 1;
+    const id = 2;
+    const url = endpoints.organize.uploads.move(id);
+    sendRequest.mockImplementation(() => true);
+
+    expect(moveUploadApi(folderId, id)).toBe(sendRequest({}));
+    expect(sendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url,
+        method: "PATCH",
+        headers: {
+          Authorization: getToken(),
+          folderId,
+        },
+        queryParams: {
+          // Set the recursive false to reduce amount of data in response
+          recursive: false,
+        },
+      })
+    );
+  });
+
+  test("copyUploadApi", () => {
+    const folderId = 1;
+    const id = 2;
+    const url = endpoints.organize.uploads.copy(id);
+    sendRequest.mockImplementation(() => true);
+
+    expect(copyUploadApi(folderId, id)).toBe(sendRequest({}));
+    expect(sendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url,
+        method: "PUT",
+        headers: {
+          Authorization: getToken(),
+          folderId,
+        },
+        queryParams: {
+          // Set the recursive false to reduce amount of data in response
+          recursive: false,
+        },
+      })
+    );
+  });
+});

--- a/src/api/search.test.js
+++ b/src/api/search.test.js
@@ -1,0 +1,72 @@
+/*
+ Copyright (C) 2021 Edgar Sherman (edgarshermangh14@gmail.com)
+ SPDX-License-Identifier: GPL-2.0
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+import sendRequest from "api/sendRequest";
+import endpoints from "constants/endpoints";
+import { getToken } from "shared/authHelper";
+import searchApi from "api/search";
+
+jest.mock("api/sendRequest");
+
+describe("search", () => {
+  test("searchApi", () => {
+    const searchType = "searchType";
+    const uploadId = 1;
+    const filename = "filename";
+    const tag = "tag";
+    const filesizemin = 2;
+    const filesizemax = 3;
+    const license = "license";
+    const copyright = "copyright";
+    const page = 4;
+    const limit = 5;
+    const url = endpoints.search.search();
+    sendRequest.mockImplementation(() => true);
+
+    expect(
+      searchApi({
+        searchType,
+        uploadId,
+        filename,
+        tag,
+        filesizemin,
+        filesizemax,
+        license,
+        copyright,
+        page,
+        limit,
+      })
+    ).toBe(sendRequest({}));
+    expect(sendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url,
+        method: "GET",
+        headers: {
+          Authorization: getToken(),
+          searchType,
+          uploadId,
+          filename,
+          tag,
+          filesizemin,
+          filesizemax,
+          license,
+          copyright,
+          page,
+          limit,
+        },
+      })
+    );
+  });
+});

--- a/src/api/sendRequest.test.js
+++ b/src/api/sendRequest.test.js
@@ -1,0 +1,265 @@
+/*
+ Copyright (C) 2021 Edgar Sherman (edgarshermangh14@gmail.com)
+ SPDX-License-Identifier: GPL-2.0
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+import { disableFetchMocks, enableFetchMocks } from "jest-fetch-mock";
+import { stringify } from "query-string";
+import { setLocalStorage } from "shared/storageHelper";
+import { logout } from "shared/authHelper";
+import sendRequest from "api/sendRequest";
+
+jest.mock("shared/storageHelper", () => ({
+  getLocalStorage: jest.fn(),
+  setLocalStorage: jest.fn(),
+}));
+
+jest.mock("shared/authHelper", () => ({
+  logout: jest.fn(),
+}));
+
+describe("sendRequest", () => {
+  let defaultArgs;
+  beforeEach(() => {
+    jest.useFakeTimers();
+    enableFetchMocks();
+    fetch.doMock();
+
+    defaultArgs = {
+      url: "url",
+      method: "GET",
+      body: null,
+      groupName: "myGroupName",
+      queryParams: null,
+    };
+  });
+
+  afterEach(() => {
+    disableFetchMocks();
+  });
+
+  test("basic call for sendRequest", async () => {
+    fetch.mockResponse(JSON.stringify({}));
+
+    await sendRequest(defaultArgs);
+
+    expect(fetch).toHaveBeenCalledWith(
+      defaultArgs.url,
+      expect.objectContaining({
+        body: defaultArgs.body,
+        headers: new Headers({
+          "content-type": "application/json",
+          accept: "application/json",
+          groupName: "myGroupName",
+          ...defaultArgs.headers,
+        }),
+        method: defaultArgs.method,
+      })
+    );
+  });
+
+  test("sendRequest handles isMultipart", async () => {
+    defaultArgs.method = "POST";
+    defaultArgs.body = {};
+    defaultArgs.isMultipart = true;
+    fetch.mockResponse(JSON.stringify({}));
+
+    await sendRequest(defaultArgs);
+
+    expect(fetch).toHaveBeenCalledWith(
+      defaultArgs.url,
+      expect.objectContaining({
+        body: defaultArgs.body,
+        headers: new Headers({
+          groupName: "myGroupName",
+          ...defaultArgs.headers,
+        }),
+        method: defaultArgs.method,
+      })
+    );
+  });
+
+  test("sendRequest handles isFile", async () => {
+    defaultArgs.isFile = true;
+    defaultArgs.method = "POST";
+    defaultArgs.body = {};
+    fetch.mockResponse(JSON.stringify({}));
+
+    await sendRequest(defaultArgs);
+
+    expect(fetch).toHaveBeenCalledWith(
+      defaultArgs.url,
+      expect.objectContaining({
+        body: JSON.stringify(defaultArgs.body),
+        headers: new Headers({
+          groupName: "myGroupName",
+          ...defaultArgs.headers,
+        }),
+        method: defaultArgs.method,
+      })
+    );
+  });
+
+  test("sendRequest handles addGroupName", async () => {
+    defaultArgs.addGroupName = false;
+    fetch.mockResponse(JSON.stringify({}));
+
+    await sendRequest(defaultArgs);
+
+    expect(fetch).toHaveBeenCalledWith(
+      defaultArgs.url,
+      expect.objectContaining({
+        body: defaultArgs.body,
+        headers: new Headers({
+          "content-type": "application/json",
+          accept: "application/json",
+          ...defaultArgs.headers,
+        }),
+        method: defaultArgs.method,
+      })
+    );
+  });
+
+  test("sendRequest handles noHeaders", async () => {
+    defaultArgs.noHeaders = true;
+    fetch.mockResponse(JSON.stringify({}));
+
+    await sendRequest(defaultArgs);
+
+    expect(fetch).toHaveBeenCalledWith(
+      defaultArgs.url,
+      expect.objectContaining({
+        body: defaultArgs.body,
+        headers: {},
+        method: defaultArgs.method,
+      })
+    );
+  });
+
+  test("sendRequest handles credentials", async () => {
+    defaultArgs.credentials = "user:password";
+    fetch.mockResponse(JSON.stringify({}));
+
+    await sendRequest(defaultArgs);
+
+    expect(fetch).toHaveBeenCalledWith(
+      defaultArgs.url,
+      expect.objectContaining({
+        body: defaultArgs.body,
+        credentials: defaultArgs.credentials,
+        headers: new Headers({
+          "content-type": "application/json",
+          accept: "application/json",
+          groupName: "myGroupName",
+          ...defaultArgs.headers,
+        }),
+        method: defaultArgs.method,
+      })
+    );
+  });
+
+  test("sendRequest handles queryParams", async () => {
+    defaultArgs.queryParams = {
+      option1: "abc",
+      option2: "def",
+    };
+    fetch.mockResponse(JSON.stringify({}));
+
+    await sendRequest(defaultArgs);
+
+    expect(fetch).toHaveBeenCalledWith(
+      `${defaultArgs.url}?${stringify(defaultArgs.queryParams)}`,
+      expect.objectContaining({
+        body: defaultArgs.body,
+        headers: new Headers({
+          "content-type": "application/json",
+          accept: "application/json",
+          groupName: "myGroupName",
+          ...defaultArgs.headers,
+        }),
+        method: defaultArgs.method,
+      })
+    );
+  });
+
+  test("sendRequest handles response headers", async () => {
+    const pages = "1";
+    const headers = {
+      "x-total-pages": pages,
+      "Content-Type": "application/json",
+      Accept: "*/*",
+    };
+    const body = { data: {} };
+    fetch.mockResponse(JSON.stringify(body), {
+      status: 200,
+      headers,
+    });
+
+    await sendRequest(defaultArgs);
+
+    expect(setLocalStorage).toHaveBeenCalledWith("pages", pages);
+  });
+
+  test("sendRequest handles retries", async () => {
+    defaultArgs.retries = 3;
+    const body = { data: {} };
+    fetch.mockResponses(
+      [JSON.stringify(body), { status: 400 }],
+      [JSON.stringify(body), { status: 200 }]
+    );
+
+    await sendRequest(defaultArgs);
+    jest.runAllTimers();
+    await new Promise((resolve) => setImmediate(resolve));
+    jest.runAllTimers();
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  test("sendRequest handles failure", async () => {
+    const message = "message";
+    const body = { data: {}, message };
+    const status = 400;
+    fetch.mockResponse(JSON.stringify(body), { status });
+
+    await expect(sendRequest(defaultArgs)).rejects.toEqual(
+      expect.objectContaining({
+        status,
+        ok: false,
+        message,
+        body,
+      })
+    );
+  });
+
+  test("sendRequest handles 403", async () => {
+    const message = "message";
+    const status = 403;
+    fetch.mockResponses(
+      [JSON.stringify({ data: {}, code: status, message }), { status }],
+      [JSON.stringify({ data: {}, code: status }), { status }]
+    );
+
+    await sendRequest(defaultArgs);
+    expect(logout).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message,
+      })
+    );
+    await sendRequest(defaultArgs);
+    expect(logout).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Requested resource is forbidden",
+      })
+    );
+  });
+});

--- a/src/api/upload.test.js
+++ b/src/api/upload.test.js
@@ -1,0 +1,164 @@
+/*
+ Copyright (C) 2021 Edgar Sherman (edgarshermangh14@gmail.com)
+ SPDX-License-Identifier: GPL-2.0
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+import sendRequest from "api/sendRequest";
+import endpoints from "constants/endpoints";
+import { getToken } from "shared/authHelper";
+import {
+  createUploadApi,
+  createUploadUrlApi,
+  createUploadVcsApi,
+  getUploadByIdApi,
+} from "api/upload";
+
+jest.mock("api/sendRequest");
+
+describe("upload", () => {
+  test("createUploadApi without fileInput", () => {
+    const folderId = 1;
+    const uploadDescription = "uploadDescription";
+    const accessLevel = 2;
+    const ignoreScm = true;
+    const fileInput = null;
+    const url = endpoints.upload.uploadCreate();
+    sendRequest.mockImplementation(() => true);
+
+    expect(
+      createUploadApi(
+        folderId,
+        uploadDescription,
+        accessLevel,
+        ignoreScm,
+        fileInput
+      )
+    ).toBe(sendRequest({}));
+    expect(sendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url,
+        method: "POST",
+        isMultipart: true,
+        headers: {
+          Authorization: getToken(),
+          folderId,
+          uploadDescription,
+          accessLevel,
+          ignoreScm,
+          uploadType: "",
+        },
+        body: new FormData(),
+      })
+    );
+  });
+
+  test("createUploadApi with fileInput", () => {
+    const folderId = 1;
+    const uploadDescription = "uploadDescription";
+    const accessLevel = 2;
+    const ignoreScm = true;
+    const fileInput = new File(["My File"], "file.txt", {
+      type: "text/plain",
+    });
+    const expectedBody = new FormData();
+    expectedBody.append("fileInput", fileInput, fileInput?.name);
+    const url = endpoints.upload.uploadCreate();
+    sendRequest.mockImplementation(() => true);
+
+    expect(
+      createUploadApi(
+        folderId,
+        uploadDescription,
+        accessLevel,
+        ignoreScm,
+        fileInput
+      )
+    ).toBe(sendRequest({}));
+    expect(sendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url,
+        method: "POST",
+        isMultipart: true,
+        headers: {
+          Authorization: getToken(),
+          folderId,
+          uploadDescription,
+          accessLevel,
+          ignoreScm,
+          uploadType: "",
+        },
+        body: expectedBody,
+      })
+    );
+  });
+
+  test("createUploadVcsApi", () => {
+    const header = "header";
+    const body = "body";
+    const url = endpoints.upload.uploadCreate();
+    sendRequest.mockImplementation(() => true);
+
+    expect(createUploadVcsApi(header, body)).toBe(sendRequest({}));
+    expect(sendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url,
+        method: "POST",
+        credentials: false,
+        headers: {
+          ...header,
+          Authorization: getToken(),
+        },
+        body,
+      })
+    );
+  });
+
+  test("createUploadUrlApi", () => {
+    const header = "header";
+    const body = "body";
+    const url = endpoints.upload.uploadCreate();
+    sendRequest.mockImplementation(() => true);
+
+    expect(createUploadUrlApi(header, body)).toBe(sendRequest({}));
+    expect(sendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url,
+        method: "POST",
+        headers: {
+          ...header,
+          Authorization: getToken(),
+        },
+        body,
+      })
+    );
+  });
+
+  test("getUploadByIdApi", () => {
+    const uploadId = 1;
+    const retries = 2;
+    const url = endpoints.upload.getId(uploadId);
+    sendRequest.mockImplementation(() => true);
+
+    expect(getUploadByIdApi(uploadId, retries)).toBe(sendRequest({}));
+    expect(sendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url,
+        method: "GET",
+        retries,
+        headers: {
+          Authorization: getToken(),
+        },
+      })
+    );
+  });
+});

--- a/src/api/users.test.js
+++ b/src/api/users.test.js
@@ -1,0 +1,75 @@
+/*
+ Copyright (C) 2021 Edgar Sherman (edgarshermangh14@gmail.com)
+ SPDX-License-Identifier: GPL-2.0
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+import sendRequest from "api/sendRequest";
+import endpoints from "constants/endpoints";
+import { getToken } from "shared/authHelper";
+import { deleteUserApi, getAllUsersApi, getUserSelfApi } from "api/users";
+
+jest.mock("api/sendRequest");
+
+describe("users", () => {
+  test("getUserSelfApi", () => {
+    const url = endpoints.users.self();
+    sendRequest.mockImplementation(() => true);
+
+    expect(getUserSelfApi()).toBe(sendRequest({}));
+    expect(sendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url,
+        method: "GET",
+        headers: {
+          Authorization: getToken(),
+        },
+        addGroupName: false,
+      })
+    );
+  });
+
+  test("getAllUsersApi", () => {
+    const url = endpoints.users.getAll();
+    sendRequest.mockImplementation(() => true);
+
+    expect(getAllUsersApi()).toBe(sendRequest({}));
+    expect(sendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url,
+        method: "GET",
+        credentials: "include",
+        headers: {
+          Authorization: getToken(),
+        },
+      })
+    );
+  });
+
+  test("deleteUserApi", () => {
+    const id = 1;
+    const url = endpoints.users.delete(id);
+    sendRequest.mockImplementation(() => true);
+
+    expect(deleteUserApi(id)).toBe(sendRequest({}));
+    expect(sendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url,
+        method: "DELETE",
+        credentials: "include",
+        headers: {
+          Authorization: getToken(),
+        },
+      })
+    );
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5195,6 +5195,13 @@ create-react-context@0.3.0:
     gud "^1.0.0"
     warning "^4.0.3"
 
+cross-fetch@^3.0.4:
+  version "3.1.4"
+  resolved "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz#9723f3a3a247bf8b89039f3a380a9244e8fa2f39"
+  integrity sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==
+  dependencies:
+    node-fetch "2.6.1"
+
 cross-spawn@7.0.3, cross-spawn@^7.0.0, cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -8637,6 +8644,14 @@ jest-environment-node@^26.6.2:
     jest-mock "^26.6.2"
     jest-util "^26.6.2"
 
+jest-fetch-mock@3.0.3:
+  version "3.0.3"
+  resolved "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz#31749c456ae27b8919d69824f1c2bd85fe0a1f3b"
+  integrity sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==
+  dependencies:
+    cross-fetch "^3.0.4"
+    promise-polyfill "^8.1.3"
+
 jest-get-type@^26.3.0:
   version "26.3.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.3.0.tgz#e97dc3c3f53c2b406ca7afaed4493b1d099199e0"
@@ -9883,7 +9898,7 @@ node-dir@^0.1.10:
   dependencies:
     minimatch "^3.0.2"
 
-node-fetch@^2.6.1:
+node-fetch@2.6.1, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
@@ -11407,6 +11422,11 @@ promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
+
+promise-polyfill@^8.1.3:
+  version "8.2.0"
+  resolved "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.0.tgz#367394726da7561457aba2133c9ceefbd6267da0"
+  integrity sha512-k/TC0mIcPVF6yHhUvwAp7cvL6I2fFV7TzF1DuGPI8mBh4QQazf36xCKEHKTZKRysEoTQoQdKyP25J8MPJp7j5g==
 
 promise.allsettled@^1.0.0:
   version "1.0.4"


### PR DESCRIPTION
## Description

Added unit tests to increase coverage

### Changes
- Added `jest-fetch-mock` to help with mocking `fetch`
- Tests added for the API folder

## How to test

yarn test --coverage

This submission is in reference to an open Hacktoberfest issue #159, however there are a lot more tests that could be added.  If I find more time, I'll look at adding more tests, but welcome others to add as well.