### PR TITLE
docs(README.md): rewrote a shell command in a single line.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,7 @@ FOSSology comes with a Dockerfile allowing the containerized execution.
 Run the following commands inside the project directory.
 
 ```sh
-docker build \
--t fossologyui:react1.0 \
---build-arg REACT_APP_SERVER_URL="localhost/repo/api/v2" \
---build-arg REACT_APP_HTTPS="false" .
+docker build -t fossologyui:react1.0 --build-arg REACT_APP_SERVER_URL="localhost/repo/api/v2" --build-arg REACT_APP_HTTPS="false" .
 ```
 
 ```sh


### PR DESCRIPTION
## Description

rewrote the command  "docker build" in a single line. The former was not working.

### Changes
from:
```sh
docker build \
-t fossologyui:react1.0 \
--build-arg REACT_APP_SERVER_URL="localhost/repo/api/v2" \
--build-arg REACT_APP_HTTPS="false" .
```
to:
```sh
docker build -t fossologyui:react1.0 --build-arg REACT_APP_SERVER_URL="localhost/repo/api/v2" --build-arg REACT_APP_HTTPS="false" .
```