### PR TITLE
feat: Dark theme toggle button

### DIFF
--- a/src/components/DarkThemeToggle/DarkThemeToggle.css
+++ b/src/components/DarkThemeToggle/DarkThemeToggle.css
@@ -1,47 +1,46 @@
 .toggle-button--container {
-    width: 55px;
-    height: 55px;
-    position: relative;
-  }
-  
-  .toggle-button--checkbox {
-    opacity: 0;
-    position: absolute;
-  }
-  
-  .toggle-button--label {
-    width: 40px;
-    height: 40px;
-    background-color: #fff;
-    display: flex;
-    border-radius: 50%;
-    align-items: center;
-    justify-content: center;
-    padding: 5px;
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    cursor: pointer;
-    transition: all 2s ease-out;
-  }
-  .toggle-button--sun {
-    opacity: 0;
-    transition: all 0.5s ease-out;
-    color: #dc3545;
-  }
-  
-  .toggle-button--moon {
-    opacity: 0;
-    transition: all 0.5s ease-out;
-    color: #525252;
-  }
-  
-  .toggle-button--label.light .toggle-button--sun {
-    opacity: 1;
-  }
-  
-  .toggle-button--label.dark .toggle-button--moon {
-    opacity: 1;
-  }
-  
+  width: 55px;
+  height: 55px;
+  position: relative;
+}
+
+.toggle-button--checkbox {
+  opacity: 0;
+  position: absolute;
+}
+
+.toggle-button--label {
+  width: 40px;
+  height: 40px;
+  background-color: #fff;
+  display: flex;
+  border-radius: 50%;
+  align-items: center;
+  justify-content: center;
+  padding: 5px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  cursor: pointer;
+  transition: all 2s ease-out;
+}
+.toggle-button--sun {
+  opacity: 0;
+  transition: all 0.5s ease-out;
+  color: #dc3545;
+}
+
+.toggle-button--moon {
+  opacity: 0;
+  transition: all 0.5s ease-out;
+  color: #525252;
+}
+
+.toggle-button--label.light .toggle-button--sun {
+  opacity: 1;
+}
+
+.toggle-button--label.dark .toggle-button--moon {
+  opacity: 1;
+}

--- a/src/components/DarkThemeToggle/DarkThemeToggle.css
+++ b/src/components/DarkThemeToggle/DarkThemeToggle.css
@@ -1,0 +1,47 @@
+.toggle-button--container {
+    width: 55px;
+    height: 55px;
+    position: relative;
+  }
+  
+  .toggle-button--checkbox {
+    opacity: 0;
+    position: absolute;
+  }
+  
+  .toggle-button--label {
+    width: 40px;
+    height: 40px;
+    background-color: #fff;
+    display: flex;
+    border-radius: 50%;
+    align-items: center;
+    justify-content: center;
+    padding: 5px;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    cursor: pointer;
+    transition: all 2s ease-out;
+  }
+  .toggle-button--sun {
+    opacity: 0;
+    transition: all 0.5s ease-out;
+    color: #dc3545;
+  }
+  
+  .toggle-button--moon {
+    opacity: 0;
+    transition: all 0.5s ease-out;
+    color: #525252;
+  }
+  
+  .toggle-button--label.light .toggle-button--sun {
+    opacity: 1;
+  }
+  
+  .toggle-button--label.dark .toggle-button--moon {
+    opacity: 1;
+  }
+  

--- a/src/components/DarkThemeToggle/DarkThemeToggle.jsx
+++ b/src/components/DarkThemeToggle/DarkThemeToggle.jsx
@@ -1,0 +1,39 @@
+/* eslint-disable jsx-a11y/label-has-associated-control */
+import React, { useContext } from "react";
+import "./DarkThemeToggle.css";
+import { MoonStarsFill, BrightnessHighFill } from "react-bootstrap-icons";
+
+// Global Context for theme
+import { GlobalContext } from "context";
+
+const DarkThemeToggle = () => {
+  const { state, setTheme } = useContext(GlobalContext);
+
+  const handleTheme = () => {
+    setTheme(`${state.theme === "light" ? "dark" : "light"}`);
+  };
+
+  return (
+    <div className="toggle-button--container">
+      <input
+        type="checkbox"
+        className="toggle-button--checkbox"
+        value={state.theme}
+        id="checkbox"
+        onChange={() => handleTheme()}
+      />
+      <label
+        htmlFor="checkbox"
+        className={`${state.theme} toggle-button--label`}
+      >
+        {state.theme !== "light" ? (
+          <MoonStarsFill className="toggle-button--moon" size={20} />
+        ) : (
+          <BrightnessHighFill className="toggle-button--sun" size={22} />
+        )}
+      </label>
+    </div>
+  );
+};
+
+export default DarkThemeToggle;

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -17,7 +17,7 @@
 */
 
 // React Imports
-import React, { useState, useContext } from "react";
+import React, { useState } from "react";
 import { useHistory, Link, useLocation } from "react-router-dom";
 
 // React Bootstrap Imports
@@ -46,19 +46,18 @@ import routes from "constants/routes";
 // External Link for documention
 import externalLinks from "constants/externalLinks";
 
-// Global Context for theme
-import { GlobalContext } from "context";
-
 // Helper Functions
 import { logout, isAuth, getUserName, isAdmin } from "shared/authHelper";
 import { getLocalStorage, setLocalStorage } from "shared/storageHelper";
 import { getNameInitials } from "shared/helper";
 
+// Dark Theme Toggle Button
+import DarkThemeToggle from "../DarkThemeToggle/DarkThemeToggle";
+
 const Header = () => {
   const [currentGroup, setCurrentGroup] = useState(
     getLocalStorage("currentGroup") || getLocalStorage("user")?.default_group
   );
-  const { setTheme } = useContext(GlobalContext);
   const history = useHistory();
   const location = useLocation();
   const handleLogin = () => {
@@ -306,7 +305,11 @@ const Header = () => {
               </>
             )}
           </Nav>
-
+          <Dropdown drop="left">
+            <Dropdown.Toggle variant="link" bsPrefix="p-0">
+              <DarkThemeToggle />
+            </Dropdown.Toggle>
+          </Dropdown>
           {/* Help Pages */}
           <Dropdown drop="left">
             <Dropdown.Toggle variant="link" bsPrefix="p-0">
@@ -357,7 +360,6 @@ const Header = () => {
               </Dropdown.Menu>
             </Dropdown>
           )}
-
           <Dropdown drop="left">
             <Dropdown.Toggle variant="link" bsPrefix="p-0">
               <PersonCircle color="#fff" size={40} className="m-2" />
@@ -372,23 +374,11 @@ const Header = () => {
                   Log out
                 </Dropdown.Item>
                 <Dropdown.Divider />
-                <Dropdown.Item onClick={() => setTheme("light")}>
-                  Light Theme
-                </Dropdown.Item>
-                <Dropdown.Item onClick={() => setTheme("dark")}>
-                  Dark Theme
-                </Dropdown.Item>
               </Dropdown.Menu>
             ) : (
               <Dropdown.Menu>
                 <Dropdown.Item onClick={handleLogin}>Log in</Dropdown.Item>
                 <Dropdown.Divider />
-                <Dropdown.Item onClick={() => setTheme("light")}>
-                  Light Theme
-                </Dropdown.Item>
-                <Dropdown.Item onClick={() => setTheme("dark")}>
-                  Dark Theme
-                </Dropdown.Item>
               </Dropdown.Menu>
             )}
           </Dropdown>

--- a/src/context/index.jsx
+++ b/src/context/index.jsx
@@ -45,6 +45,7 @@ export const GlobalProvider = ({ children }) => {
     <GlobalContext.Provider
       value={{
         ...state,
+        state,
         setTheme,
       }}
     >


### PR DESCRIPTION
## Description
When someone click on the profile then only he/she can able to know about the dark theme. To create better user experience the dark theme button should be on navigation.

### Changes
 :- add dark theme toggle button on the navigation
 :- to make the button in such a way that it would not take much space, I changed the expected UI(suggested by @GMishx )

### On desktop:-
Light theme:-
![image](https://user-images.githubusercontent.com/55187056/154297524-a9a800d0-55aa-42ad-a1e1-ad68b046eec9.png)

Dark theme:-
![image](https://user-images.githubusercontent.com/55187056/154297703-8df21091-e52a-4a21-818d-f855752dfdba.png)

### On mobile
Light theme:-
![image](https://user-images.githubusercontent.com/55187056/154297881-018cb278-9937-44cc-a81b-a851ec05d76e.png)

Dark theme:-
![image](https://user-images.githubusercontent.com/55187056/154298024-7636f7bb-e133-4ce1-8283-0e066d35c3dd.png)

Closes #173