### PR TITLE
fix(ui): light and dark mode refresh bug fixed

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -36,15 +36,21 @@ import "styles/global.css";
 import GlobalStyles from "styles/globalStyle";
 
 function App() {
-  const { theme } = useContext(GlobalContext);
+  const { state } = useContext(GlobalContext);
+  return (
+    <ThemeProvider theme={state.theme === "light" ? lightTheme : darkTheme}>
+      <GlobalStyles />
+      <Routes />
+    </ThemeProvider>
+  );
+}
+
+function AppWrapper() {
   return (
     <GlobalProvider>
-      <ThemeProvider theme={theme === "light" ? lightTheme : darkTheme}>
-        <GlobalStyles />
-        <Routes />
-      </ThemeProvider>
+      <App />
     </GlobalProvider>
   );
 }
 
-export default App;
+export default AppWrapper;

--- a/src/context/index.jsx
+++ b/src/context/index.jsx
@@ -36,15 +36,13 @@ export const GlobalProvider = ({ children }) => {
 
   // Actions
   const setTheme = (theme) => {
-    setState(theme);
+    setState({ theme });
     setLocalStorage("theme", theme);
-    window.location.reload();
   };
 
   return (
     <GlobalContext.Provider
       value={{
-        ...state,
         state,
         setTheme,
       }}


### PR DESCRIPTION
Signed-off-by: Devesh <deves125@gmail.com>

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/FOSSologyUI/blob/main/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

This bug was occurring because of a few reasons:
1. Irregularities in the naming of variables made it confusing to know what a variable actually contains.
2. `useContext` hook was implemented incorrectly. The way it was implemented is a very common mistake so it was easy to catch.


### Changes
1. I fixed the useContext implementation.
2. Removed the line which made the page refresh.

---

### My Suggestion

1. Since the theme variable can only contain two values (`light` and `dark`), can we convert that into a boolean? That would make the logic much simpler.

2. I did not fix the naming convention. In the context file, we are exporting a `state` variable and a `setTheme` variable which might cause confusion.

I would like to discuss it before changing anything as it could cause confusion. 👍

---

### Screenshot

![brave_bohFfjKKy2](https://user-images.githubusercontent.com/59534570/157693152-8632cea6-f179-4b78-a38f-81fbb44132d3.gif)



## How to test
You can simply toggle the theme change button


Please consider using the closing keyword if the pull request is proposed to
fix an issue already created in the repository
(https://help.github.com/articles/closing-issues-using-keywords/)