### PR TITLE
fix (components/widgets/input): Warning while loading delete user page

### DIFF
--- a/src/components/Widgets/Input/index.jsx
+++ b/src/components/Widgets/Input/index.jsx
@@ -35,7 +35,6 @@ const InputContainer = ({
   property,
   valueProperty,
   noDataMessage = "No Data Found",
-  defaultValue = null,
 }) => {
   if (type === "radio" || type === "checkbox") {
     return (
@@ -75,7 +74,6 @@ const InputContainer = ({
           multiple={multiple && multiple}
           size={multiple ? "15" : ""}
           id={id}
-          defaultValue={defaultValue}
         >
           {options.length > 0 ? (
             options.map((option, index) => (
@@ -141,7 +139,6 @@ InputContainer.propTypes = {
   property: PropTypes.string,
   valueProperty: PropTypes.string,
   noDataMessage: PropTypes.string,
-  defaultValue: PropTypes.string,
 };
 
 export default InputContainer;


### PR DESCRIPTION
## Description

This PR is in reference to the issue #167 . A warning in the console stated an error like below,
```
Warning: Select elements must be either controlled or uncontrolled (specify either the value prop, or the defaultValue prop, but not both). Decide between using a controlled or uncontrolled select element and remove one of these props. More info: https://reactjs.org/link/controlled-components
select
```
This occurs when we try to use `value` and `defaultValue` prop inside a select tag simultaneously.

### Changes

The solution is to remove one of the `value` or `defaultValue` prop.

Note: This PR also have the fixes for [undefined value for currentGroup in local storage](https://github.com/fossology/FOSSologyUI/pull/179#issuecomment-1073585315)

This PR closes #167 .