### PR TITLE
feat(delete user): Disabled deletion of default users

### DIFF
--- a/src/pages/Admin/Users/Delete/index.jsx
+++ b/src/pages/Admin/Users/Delete/index.jsx
@@ -40,6 +40,7 @@ const DeleteUser = () => {
     {
       id: 0,
       name: "string",
+      disabled: false,
     },
   ];
   const initialMessage = {
@@ -70,6 +71,22 @@ const DeleteUser = () => {
     }
   };
 
+  /* Defaults for the dropdown */
+  const setDefaultsForDropdown = (res) => {
+    let userList = res.map((user) => ({
+      ...user,
+      disabled: !(user.name !== "fossy" && user.name !== "Default User"),
+    }));
+    setUsersList(userList);
+    userList = userList.filter(
+      (user) => user.name !== "fossy" && user.name !== "Default User"
+    );
+    setDeleteUserData({
+      ...deleteUserData,
+      id: userList.length ? userList[0].id : 0,
+    });
+  };
+
   const handleSubmit = (e) => {
     e.preventDefault();
     if (confirm) {
@@ -83,11 +100,14 @@ const DeleteUser = () => {
         })
         .then(() => {
           getAllUsersName().then((res) => {
-            setUsersList(res);
+            setDefaultsForDropdown(res);
           });
         })
         .catch((error) => {
-          handleError(error, setMessage);
+          if (id === 0) {
+            const err = new Error("Default users cannot be deleted");
+            handleError(err, setMessage);
+          } else handleError(error, setMessage);
         })
         .finally(() => {
           setLoading(false);
@@ -105,7 +125,7 @@ const DeleteUser = () => {
   useEffect(() => {
     getAllUsersName()
       .then((res) => {
-        setUsersList(res);
+        setDefaultsForDropdown(res);
       })
       .catch((error) => {
         handleError(error, setMessage);


### PR DESCRIPTION
## Description

This PR is in reference to the issue #195 and discussion on [preventing the deletion of default users](https://github.com/fossology/FOSSologyUI/issues/195#issuecomment-1082661293). 

## Changes Done
- Greyed out the default users in the dropdown. 
- Added the feature to set defaults for delete user data so that the api request doesn't go invalid.

## Screenshots

https://user-images.githubusercontent.com/71918441/160777807-61cdcf87-a77e-47ec-af3c-91afb21efa0c.mov


This PR closes #195.