### PR TITLE
fix(unexpected-token): Changed name of key 

### DIFF
--- a/src/services/users.js
+++ b/src/services/users.js
@@ -23,7 +23,7 @@ import { setLocalStorage } from "shared/storageHelper";
 export const getUserSelf = () => {
   return getUserSelfApi().then((res) => {
     setLocalStorage("user", res);
-    setLocalStorage("currentGroup", res.default_group);
+    setLocalStorage("currentGroup", res.name);
     return res;
   });
 };


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/FOSSologyUI/blob/main/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Changed key of setLocalStorage() in getUserSelf() from res.default_group to res.name as key default_group is no longer included in the response from endpoint /api/v1/users/self. Changing to res.name fixed the issue.

### Changes

Changed key from res.default_group to res.name

## How to test

Login using FossologyUI

Closes #198