### PR TITLE
fix(dropdowns): Removed divider from Log out dropdown and Removed dro…

### DIFF
--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -18,7 +18,7 @@
 
 // React Imports
 import React, { useState } from "react";
-import { Link, useLocation } from "react-router-dom";
+import { useHistory, Link, useLocation } from "react-router-dom";
 
 // React Bootstrap Imports
 import {
@@ -58,7 +58,11 @@ const Header = () => {
   const [currentGroup, setCurrentGroup] = useState(
     getLocalStorage("currentGroup") || getLocalStorage("user")?.default_group
   );
+  const history = useHistory();
   const location = useLocation();
+  const handleLogin = () => {
+    history.push(routes.home);
+  };
   const handleGroupChange = (e) => {
     setLocalStorage("currentGroup", e.target.innerText);
     setCurrentGroup(e.target.innerText);
@@ -371,7 +375,9 @@ const Header = () => {
                 </Dropdown.Item>
               </Dropdown.Menu>
             ) : (
-              <div />
+              <Dropdown.Menu>
+                <Dropdown.Item onClick={handleLogin}>Log in</Dropdown.Item>
+              </Dropdown.Menu>
             )}
           </Dropdown>
         </Navbar.Collapse>


### PR DESCRIPTION
…pdown on homepage

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/FOSSologyUI/blob/main/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Closes #200 

### Changes

Removed <Dropdown.Divider /> from Log Out dropdown and Removed Log In dropdown since it served no functionality.

## Screenshots
![right-logout](https://user-images.githubusercontent.com/57453561/161704056-61a4cc5b-e492-43c7-868b-b1e8019dbb6b.png)


## How to test

1. yarn start.
2. Check Log In dropdown by clicking top right user icon.
3. Check Log Out dropdown by Logging In and clicking top right user icon.
