### PR TITLE
refactor(api): removed credentials from api request module 

### DIFF
--- a/src/api/sendRequest.js
+++ b/src/api/sendRequest.js
@@ -26,7 +26,6 @@ import { getLocalStorage, setLocalStorage } from "shared/storageHelper";
 const sendRequest = ({
   url,
   method,
-  credentials = false,
   body,
   groupName,
   headers = {},
@@ -79,10 +78,6 @@ const sendRequest = ({
     }
   } else {
     options.body = null;
-  }
-
-  if (credentials) {
-    options.credentials = credentials;
   }
   if (queryParams) {
     URL = `${url}?${stringify(queryParams)}`;

--- a/src/api/sendRequest.test.js
+++ b/src/api/sendRequest.test.js
@@ -146,28 +146,6 @@ describe("sendRequest", () => {
     );
   });
 
-  test("sendRequest handles credentials", async () => {
-    defaultArgs.credentials = "user:password";
-    fetch.mockResponse(JSON.stringify({}));
-
-    await sendRequest(defaultArgs);
-
-    expect(fetch).toHaveBeenCalledWith(
-      defaultArgs.url,
-      expect.objectContaining({
-        body: defaultArgs.body,
-        credentials: defaultArgs.credentials,
-        headers: new Headers({
-          "content-type": "application/json",
-          accept: "application/json",
-          groupName: "myGroupName",
-          ...defaultArgs.headers,
-        }),
-        method: defaultArgs.method,
-      })
-    );
-  });
-
   test("sendRequest handles queryParams", async () => {
     defaultArgs.queryParams = {
       option1: "abc",

--- a/src/api/upload.js
+++ b/src/api/upload.js
@@ -60,7 +60,6 @@ export const createUploadVcsApi = (header, body) => {
   return sendRequest({
     url,
     method: "POST",
-    credentials: false,
     headers: {
       ...header,
       Authorization: getToken(),

--- a/src/api/upload.test.js
+++ b/src/api/upload.test.js
@@ -113,7 +113,6 @@ describe("upload", () => {
       expect.objectContaining({
         url,
         method: "POST",
-        credentials: false,
         headers: {
           ...header,
           Authorization: getToken(),

--- a/src/api/users.js
+++ b/src/api/users.js
@@ -43,7 +43,6 @@ export const getAllUsersApi = () => {
   return sendRequest({
     url,
     method: "GET",
-    credentials: "include",
     headers: {
       Authorization: getToken(),
     },
@@ -56,7 +55,6 @@ export const deleteUserApi = (id) => {
   return sendRequest({
     url,
     method: "DELETE",
-    credentials: "include",
     headers: {
       Authorization: getToken(),
     },

--- a/src/api/users.test.js
+++ b/src/api/users.test.js
@@ -47,7 +47,6 @@ describe("users", () => {
       expect.objectContaining({
         url,
         method: "GET",
-        credentials: "include",
         headers: {
           Authorization: getToken(),
         },
@@ -65,7 +64,6 @@ describe("users", () => {
       expect.objectContaining({
         url,
         method: "DELETE",
-        credentials: "include",
         headers: {
           Authorization: getToken(),
         },


### PR DESCRIPTION
## Issue
This error appears in the console when we navigate to the delete user page.
<img width="359" alt="Screenshot 2022-05-26 at 9 31 55 PM" src="https://user-images.githubusercontent.com/71918441/170857266-20b02998-f58e-4e9d-bc59-644e910403a5.png">

## Description

This PR concerns with the fact that fossology API now doesn't require credentials to work and has been removed from the backend. So, the header needs to be removed from the frontend as well.

### Changes

~~`credentials: "includes"`~~

## How to test

`yarn test`