### PR TITLE
feat(ui): implementation of mantainance page on the admin section

### DIFF
--- a/src/Routes.jsx
+++ b/src/Routes.jsx
@@ -95,6 +95,7 @@ const AddLicense = React.lazy(() => import("pages/Admin/License/Create"));
 const SelectLicense = React.lazy(() =>
   import("pages/Admin/License/SelectLicense")
 );
+const ManageMantainance = React.lazy(() => import("pages/Admin/Mantainance"));
 
 // Default Page
 const ErrorPage = React.lazy(() => import("pages/ErrorPage"));
@@ -297,6 +298,12 @@ const Routes = () => {
             exact
             path={routes.admin.users.delete}
             component={DeleteUser}
+          />
+
+          <AdminLayout
+            exact
+            path={routes.admin.mantainance}
+            component={ManageMantainance}
           />
 
           {/* Default Page */}

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -276,6 +276,7 @@ const Header = () => {
                         </NavDropdown.Item>
                       </div>
                     </DropdownButton>
+
                     <DropdownButton
                       variant=""
                       drop="right"
@@ -303,6 +304,10 @@ const Header = () => {
                         </NavDropdown.Item>
                       </div>
                     </DropdownButton>
+
+                    <NavDropdown.Item as={Link} to={routes.admin.mantainance}>
+                      Mantainance
+                    </NavDropdown.Item>
                   </NavDropdown>
                 )}
               </>

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -241,3 +241,22 @@ export const initialFolderList = [
     parent: null,
   },
 ];
+
+export const initialMantainanceFields = {
+  allNonSlow: false,
+  allOperations: false,
+  validateFolderContents: false,
+  rmvGoldFiles: false,
+  rmvOrphanedRows: false,
+  rmvLogFiles: false,
+  normalizePriority: false,
+  rmvUploads: false,
+  rmvTokens: false,
+  rmvTempTables: false,
+  analyseDb: false,
+  rmvRepoFiles: false,
+  dbReindexing: false,
+  verbose: false,
+  rmvRepoOldFiles1: false,
+  rmvRepoOldFiles2: false,
+};

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -76,6 +76,7 @@ const routes = {
       selectLicense: "/admin/selectLicense",
       licenseCSV: "/licenseCSV/fossology-license-export.csv",
     },
+    mantainance: "/admin/mantainance",
   },
   browseUploads: {
     softwareHeritage: "/browse/softwareHeritage",

--- a/src/pages/Admin/Mantainance/index.jsx
+++ b/src/pages/Admin/Mantainance/index.jsx
@@ -1,0 +1,278 @@
+/*
+ Copyright (C) 2022 Samuel Dushimimana (dushsam100@gmail.com)
+ 
+ SPDX-License-Identifier: GPL-2.0
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+import React, { useState } from "react";
+
+// Title
+import Title from "components/Title";
+import { Button, InputContainer, Spinner } from "components/Widgets";
+import { initialMantainanceFields } from "constants/constants";
+
+const ManageMantainance = () => {
+  const [loading, setLoading] = useState(false);
+  const [fields, setFields] = useState(initialMantainanceFields);
+
+  const handleChange = (e) => {
+    const { name } = e.target;
+
+    if (Object.keys(fields).find((field) => field === name)) {
+      setFields({ ...fields, [e.target.name]: e.target.checked });
+    }
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    setLoading(true);
+
+    setTimeout(() => {
+      setLoading(false);
+    }, 3000);
+  };
+  return (
+    <>
+      <Title title="FOSSology Maintenance" />
+      <div className="container">
+        <div className="row">
+          <div className="col-12">
+            <h1 className="font-size-main-heading mt-4">
+              FOSSology Maintenance
+            </h1>
+          </div>
+          <div className="col-12">
+            <form className="my-3">
+              <InputContainer
+                type="checkbox"
+                checked={fields.allNonSlow}
+                name="allNonSlow"
+                className="my-3"
+                id="all-non-slow"
+                onChange={(e) => handleChange(e)}
+              >
+                Run all non slow maintenance operations.
+              </InputContainer>
+
+              <InputContainer
+                type="checkbox"
+                checked={fields.allOperations}
+                name="allOperations"
+                className="my-3"
+                id="all-operations"
+                onChange={(e) => handleChange(e)}
+              >
+                Run all maintenance operations.
+              </InputContainer>
+
+              <InputContainer
+                type="checkbox"
+                checked={fields.validateFolderContents}
+                name="validateFolderContents"
+                className="my-3"
+                id="validate-folder-contents"
+                onChange={(e) => handleChange(e)}
+              >
+                Validate folder contents.
+              </InputContainer>
+
+              <InputContainer
+                type="checkbox"
+                checked={fields.rmvGoldFiles}
+                name="rmvGoldFiles"
+                className="my-3"
+                id="remove-gold-files"
+                onChange={(e) => handleChange(e)}
+              >
+                Remove orphaned gold files.
+              </InputContainer>
+
+              <InputContainer
+                type="checkbox"
+                checked={fields.rmvOrphanedRows}
+                name="rmvOrphanedRows"
+                className="my-3"
+                id="remove-orphaned-rows"
+                onChange={(e) => handleChange(e)}
+              >
+                Remove orphaned rows from database.
+              </InputContainer>
+
+              <InputContainer
+                type="checkbox"
+                checked={fields.rmvLogFiles}
+                name="rmvLogFiles"
+                className="my-3"
+                id="remove-log-files"
+                onChange={(e) => handleChange(e)}
+              >
+                Remove orphaned log files from file system.
+              </InputContainer>
+
+              <InputContainer
+                type="checkbox"
+                checked={fields.normalizePriority}
+                name="normalizePriority"
+                className="my-3"
+                id="normalize-priority"
+                onChange={(e) => handleChange(e)}
+              >
+                Normalize priority
+              </InputContainer>
+
+              <InputContainer
+                type="checkbox"
+                checked={fields.rmvUploads}
+                name="rmvUploads"
+                className="my-3"
+                id="remove-uploads"
+                onChange={(e) => handleChange(e)}
+              >
+                Remove uploads with no pfiles.
+              </InputContainer>
+
+              <InputContainer
+                type="checkbox"
+                checked={fields.rmvTokens}
+                name="rmvTokens"
+                className="my-3"
+                id="remove-tokens"
+                onChange={(e) => handleChange(e)}
+              >
+                Remove expired personal access tokens.
+              </InputContainer>
+
+              <InputContainer
+                type="checkbox"
+                checked={fields.rmvTempTables}
+                name="rmvTempTables"
+                className="my-3"
+                id="remove-temp-tables"
+                onChange={(e) => handleChange(e)}
+              >
+                Remove orphaned temp tables.
+              </InputContainer>
+
+              <InputContainer
+                type="checkbox"
+                checked={fields.analyseDb}
+                name="analyseDb"
+                className="my-3"
+                id="analyse-db"
+                onChange={(e) => handleChange(e)}
+              >
+                Vacuum Analyze the database.
+              </InputContainer>
+
+              <InputContainer
+                type="checkbox"
+                checked={fields.rmvRepoFiles}
+                name="rmvRepoFiles"
+                className="my-3"
+                id="remove-repo-files"
+                onChange={(e) => handleChange(e)}
+              >
+                Remove orphaned files from the repository (slow).
+              </InputContainer>
+
+              <InputContainer
+                type="checkbox"
+                checked={fields.dbReindexing}
+                name="dbReindexing"
+                className="my-3"
+                id="database-reindexing"
+                onChange={(e) => handleChange(e)}
+              >
+                Reindexing of database (This activity may take 5-10 mins.
+                Execute only when system is not in use).
+              </InputContainer>
+
+              <InputContainer
+                type="checkbox"
+                checked={fields.verbose}
+                name="verbose"
+                className="my-3"
+                id="verbose"
+                onChange={(e) => handleChange(e)}
+              >
+                Verbose (turns on debugging output).
+              </InputContainer>
+
+              <InputContainer
+                type="checkbox"
+                checked={fields.rmvRepoOldFiles1}
+                name="rmvRepoOldFiles1"
+                className="mt-3"
+                id="rmv-repo-old-files-1"
+                onChange={(e) => handleChange(e)}
+              >
+                Remove older gold files from repository.
+              </InputContainer>
+
+              <InputContainer
+                type="date"
+                className="col-3"
+                name="rmvRepoOldFiles1Date"
+                id="remove-repo-old-files-1-date"
+              />
+
+              <InputContainer
+                type="checkbox"
+                checked={fields.rmvRepoOldFiles2}
+                name="rmvRepoOldFiles2"
+                className="mt-3"
+                id="rmv-repo-old-files-2"
+                onChange={(e) => handleChange(e)}
+              >
+                Remove older gold files from repository.
+              </InputContainer>
+
+              <InputContainer
+                type="date"
+                className="col-3"
+                name="rmvRepoOldFiles1Date"
+                id="remove-repo-old-files-1-date"
+              />
+
+              <Button type="submit" onClick={handleSubmit} className="mt-4">
+                {loading ? (
+                  <Spinner
+                    as="span"
+                    animation="border"
+                    size="sm"
+                    role="status"
+                    aria-hidden="true"
+                  />
+                ) : (
+                  "Queue the maintanance agent"
+                )}
+              </Button>
+            </form>
+            <div className="my-3">
+              <span className="mr-2">
+                More information about these operations can be found
+              </span>
+              <a href="https://github.com/fossology/fossology/wiki/Maintenance-Agent">
+                here
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default ManageMantainance;


### PR DESCRIPTION
Signed-off-by: dushimsam <dushsam100@gmail.com>

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/FOSSologyUI/blob/main/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->


## Description

Implemented the maintenance page from the Admin section. The page is on the route `/admin/mantainance`

### Changes

1. Created a new directory ,`src/pages/admin/Mantainance/index.jsx`
2. Imported and added the new page in the `src/Routes.jsx` as a part of `AdminLayout`
3. Added a new navigation dropdown Item as a part of the admin dropdowns.
4.  Added the route and initial field values for the new page in `src/constants/routes.js`.


### How to test
1. Go in the project's main directory.
2. run command `npm start`
3. Visit the page at `http://localhost:PORT/admin/mantainance` 
4. You should see something looking like this 

##Screenshots
![Selection_006](https://user-images.githubusercontent.com/66276301/174822603-6384ac39-f2ec-48d9-acfd-728a84f3bd3e.png)
![Selection_007](https://user-images.githubusercontent.com/66276301/174822627-f17f3729-9f25-4cf0-b0c7-6e1b0d8a9692.png)


#### Related Issue:
Fixes #227 

@shaheemazmalmmd @GMishx