### PR TITLE
fix(licenses): header fixed and limit for responses removed

### DIFF
--- a/src/pages/BrowseUploads/LicenseBrowser/index.jsx
+++ b/src/pages/BrowseUploads/LicenseBrowser/index.jsx
@@ -69,7 +69,7 @@ const LicenseBrowser = () => {
           handleError(error, setMessage);
           setShowMessage(true);
         });
-      getUploadLicense(uploadId, ["ojo", "nomos", "monk"])
+      getUploadLicense(uploadId, ["ojo,nomos,monk"])
         .then((res) => {
           setFilesData(res);
           setShowMessage(false);
@@ -117,22 +117,45 @@ const LicenseBrowser = () => {
               <tbody>
                 {filesData &&
                   filesData.length > 0 &&
-                  filesData.map((data, index) => (
-                    <>
-                      {index < 10 ? (
+                  filesData.map((data) => {
+                    const filteredScanner = [...new Set(data.findings.scanner)];
+                    const filteredConclusion = [
+                      ...new Set(data.findings.conclusion),
+                    ];
+
+                    return (
+                      <>
                         <tr key={data.id}>
                           <td>{data.filePath}</td>
-                          <td>{data.findings.scanner}</td>
-                          <td>-</td>
+                          <td>
+                            {filteredScanner !== null
+                              ? filteredScanner.map((dataScanner, index) => {
+                                  return `${dataScanner}${
+                                    index + 1 === filteredScanner.length
+                                      ? ""
+                                      : ", "
+                                  }`;
+                                })
+                              : null}
+                          </td>
+                          <td>
+                            {filteredConclusion !== null
+                              ? filteredConclusion.map((dataScanner, index) => {
+                                  return `${dataScanner}${
+                                    index + 1 === filteredConclusion.length
+                                      ? ""
+                                      : ", "
+                                  }`;
+                                })
+                              : null}
+                          </td>
                           <td>-</td>
                           <td>-</td>
                           <td>-</td>
                         </tr>
-                      ) : (
-                        ""
-                      )}
-                    </>
-                  ))}
+                      </>
+                    );
+                  })}
               </tbody>
             </table>
           </div>


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/FOSSologyUI/blob/main/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Made changes in the request header of the API that was being called in order to show the licenses. Also enabled the field for edited responses. 

### Changes

Changes made in : `BrowserUploads/LicenseBrowser/index.jsx`

### Screenshots

![image](https://user-images.githubusercontent.com/63705023/180828544-f1f7687b-511e-4279-8606-b9628ecb1726.png)


## How to test

Start the server and visit a License browser page of a repository to see the updates.

PTAL: @GMishx @Shruti3004 @shaheemazmalmmd 

