### PR TITLE
feat(UI): added show jobs page to view all the jobs queued for the upload

### DIFF
--- a/src/Routes.jsx
+++ b/src/Routes.jsx
@@ -71,6 +71,7 @@ const OneShotMonk = React.lazy(() => import("pages/Upload/OneShotMonk"));
 const AllJobs = React.lazy(() => import("pages/Jobs/AllJobs"));
 const MyRecentJobs = React.lazy(() => import("pages/Jobs/MyRecentJobs"));
 const ScheduleAgents = React.lazy(() => import("pages/Jobs/ScheduleAgents"));
+const ShowJobs = React.lazy(() => import("pages/Jobs/ShowJobs"));
 
 // Organize Pages
 const DeleteFolder = React.lazy(() => import("pages/Organize/Folder/Delete"));
@@ -119,6 +120,12 @@ const Routes = () => {
 
           {/* Browse Page */}
           <PrivateLayout exact path={routes.browse} component={Browse} />
+          {/* Upload job history page */}
+          <PrivateLayout
+            exact
+            path={routes.jobs.showJobs}
+            component={ShowJobs}
+          />
 
           {/* Browse Uploads Pages */}
           <PrivateLayout

--- a/src/api/jobs.js
+++ b/src/api/jobs.js
@@ -137,4 +137,15 @@ export const downloadReportApi = (reportId) => {
   });
 };
 
+export const getUploadHistoryApi = (uploadId) => {
+  const url = endpoints.jobs.uploadHistory(uploadId);
+  return sendRequest({
+    url,
+    method: "GET",
+    headers: {
+      Authorization: getToken(),
+    },
+  });
+};
+
 export default getJobApi;

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -22,19 +22,19 @@ import { defaultAgentsList, getLocalStorage } from "shared/storageHelper";
 export const statusOptions = [
   {
     id: 0,
-    name: "open",
+    name: "Open",
   },
   {
     id: 1,
-    name: "in progress",
+    name: "InProgress",
   },
   {
     id: 2,
-    name: "closed",
+    name: "Closed",
   },
   {
     id: 3,
-    name: "rejected",
+    name: "Rejected",
   },
 ];
 
@@ -79,6 +79,11 @@ export const actionsOptions = [
     id: 5,
     name: "Export Unified Report",
     reportFormat: "unifiedreport",
+  },
+  {
+    id: 6,
+    name: "History",
+    reportFormat: "uploadHistory",
   },
 ];
 export const initialMessage = {

--- a/src/constants/endpoints.js
+++ b/src/constants/endpoints.js
@@ -17,7 +17,7 @@
 */
 
 // Api Url set in the env file
-const apiUrl = `${
+export const apiUrl = `${
   process.env.REACT_APP_HTTPS === "true" ? "https" : "http"
 }://${process.env.REACT_APP_SERVER_URL}`;
 
@@ -25,6 +25,7 @@ const apiUrl = `${
 const endpoints = {
   jobs: {
     details: (jobId) => `${apiUrl}/jobs/${jobId}`,
+    uploadHistory: (uploadId) => `${apiUrl}/jobs/history?upload=${uploadId}`,
     scheduleAnalysis: () => `${apiUrl}/jobs`,
     allJobs: () => `${apiUrl}/jobs/all`,
     scheduleReport: () => `${apiUrl}/report`,

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -37,6 +37,7 @@ const routes = {
     myRecentJobs: "/jobs/myRecentJobs",
     allRecentJobs: "/jobs/allRecentJobs",
     scheduleAgents: "/jobs/scheduleAgents",
+    showJobs: "/showJobs/:uploadId",
   },
   organize: {
     folders: {

--- a/src/pages/Jobs/ShowJobs/index.jsx
+++ b/src/pages/Jobs/ShowJobs/index.jsx
@@ -1,0 +1,126 @@
+/*
+ Copyright (C) 2022 Krishna Mahato (krishhtrishh9304@gmail.com)
+
+ SPDX-License-Identifier: GPL-2.0
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+import React, { useEffect, useState } from "react";
+
+// Title
+import Title from "components/Title";
+
+// Required functions for API and Error handling
+import { initialMessage } from "constants/constants";
+import { Alert } from "components/Widgets";
+import { useParams } from "react-router-dom";
+import { getUploadHistory } from "services/jobs";
+import { apiUrl } from "constants/endpoints";
+
+const ShowJobs = () => {
+  const [message, setMessage] = useState(initialMessage);
+  const [showMessage, setShowMessage] = useState(false);
+  const [allJobsHistoryList, setAllJobsHistoryList] = useState([]);
+  const params = useParams();
+
+  useEffect(async () => {
+    if (params.uploadId) {
+      try {
+        const allJobsHistory = await getUploadHistory(params.uploadId);
+        setAllJobsHistoryList(allJobsHistory);
+      } catch (error) {
+        setMessage(error.message);
+        setShowMessage(true);
+      }
+    }
+  }, [params]);
+
+  return (
+    <>
+      <Title title="Show Jobs" />
+      <div className="main-container my-3 text-center">
+        {showMessage && (
+          <Alert
+            type={message.type}
+            setShow={setShowMessage}
+            message={message.text}
+          />
+        )}
+        <div>
+          <div>
+            {allJobsHistoryList?.map((job) => {
+              return (
+                <table
+                  key={job.jobId}
+                  className="table table-striped text-primary-color font-size-medium table-responsive-sm table-bordered"
+                >
+                  <thead>
+                    <tr className="font-bold">
+                      <th>Job/Dependency</th>
+                      <th>Status</th>
+                      <th colSpan={3}>{job.jobName}</th>
+                      <th>Average items/sec</th>
+                      <th>ETA</th>
+                      <th>Download</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {job?.jobQueue?.map((jobQues) => {
+                      return (
+                        <tr key={jobQues.jobQueueId}>
+                          <td>
+                            {jobQues?.jobQueueId}
+                            {jobQues?.dependencies[0] &&
+                              ` / ${jobQues?.dependencies[0]}`}
+                          </td>
+                          <td>{jobQues?.status}</td>
+                          <td>{jobQues?.jobQueueType}</td>
+                          <td>
+                            {jobQues?.startTime} - {jobQues?.endTime}
+                          </td>
+                          <td>{jobQues?.itemsProcessed} items</td>
+                          <td>{jobQues?.itemsPerSec} items/sec</td>
+                          <td>
+                            {job.upload.uploadEta.length
+                              ? job.upload.uploadEta
+                              : "Scanned"}
+                          </td>
+                          <td>
+                            <a
+                              target="_blank"
+                              rel="noreferrer"
+                              href={`${apiUrl.slice(
+                                0,
+                                -7
+                              )}/?mod=download&report=${job.jobId}`}
+                            >
+                              {jobQues?.itemsProcessed !== 0 &&
+                                jobQues?.download}
+                            </a>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default ShowJobs;

--- a/src/services/jobs.js
+++ b/src/services/jobs.js
@@ -23,6 +23,7 @@ import {
   downloadReportApi,
   getAllJobApi,
   getAllAdminJobApi,
+  getUploadHistoryApi,
 } from "api/jobs";
 import { getReportIdFromUrl } from "shared/helper";
 import { getLocalStorage } from "shared/storageHelper";
@@ -77,6 +78,13 @@ export const downloadReport = (url) => {
     return null;
   }
   return downloadReportApi(reportId).then((res) => {
+    return res;
+  });
+};
+
+// Fetching the jobs history based on upload id
+export const getUploadHistory = (uploadId) => {
+  return getUploadHistoryApi(uploadId).then((res) => {
     return res;
   });
 };


### PR DESCRIPTION
## Description

This PR contains two tasks
- [x] Creation of a new page that will show all the jobs queued for an upload and all other useful information.
  - [x] Create the static UI using reusable components.
  - [x] Integrate the API from https://github.com/fossology/fossology/pull/2307
  - [x] Test Everything.
- [x] Reading the main licenses and status parameter from the backend and showing it in the browse table for each upload.

## Changes (Demo)
https://user-images.githubusercontent.com/71918441/187855237-c84d4552-e7c8-4d59-b5fb-717c5a2d0188.mov

This fixes #255 .
PTAL @Shruti3004 @GMishx @shaheemazmalmmd .
