### PR TITLE
feat(ui): Added logical components to the report import page and Integrated the API

### DIFF
--- a/src/Routes.jsx
+++ b/src/Routes.jsx
@@ -188,7 +188,7 @@ const Routes = () => {
           />
           <PrivateLayout
             exact
-            path={routes.upload.report}
+            path={routes.upload.importReport}
             component={ImportReport}
           />
           <PublicLayout

--- a/src/api/jobs.js
+++ b/src/api/jobs.js
@@ -137,4 +137,17 @@ export const downloadReportApi = (reportId) => {
   });
 };
 
+export const importReportApi = (uploadId, reqBody) => {
+  const url = endpoints.jobs.importReport(uploadId);
+  return sendRequest({
+    url,
+    method: "POST",
+    headers: {
+      Authorization: getToken(),
+    },
+    isMultipart: true,
+    body: reqBody,
+  });
+};
+
 export default getJobApi;

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -129,7 +129,7 @@ const Header = () => {
                   <NavDropdown.Item as={Link} to={routes.upload.vcs}>
                     From VCS
                   </NavDropdown.Item>
-                  <NavDropdown.Item as={Link} to={routes.upload.report}>
+                  <NavDropdown.Item as={Link} to={routes.upload.importReport}>
                     Import Report
                   </NavDropdown.Item>
                   <NavDropdown.Item as={Link} to={routes.upload.instructions}>

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -1,5 +1,5 @@
 /*
- Copyright (C) 2022 Soham Banerjee(sohambanerjee4abc@hotmail.com)
+ Copyright (C) 2022 Soham Banerjee(sohambanerjee4abc@hotmail.com), Krishna Mahato (krishhtrishh9304@gmail.com)
 
  SPDX-License-Identifier: GPL-2.0
 
@@ -80,6 +80,11 @@ export const actionsOptions = [
     name: "Export Unified Report",
     reportFormat: "unifiedreport",
   },
+  {
+    id: 6,
+    name: "Import Report",
+    reportFormat: "importReport",
+  },
 ];
 export const initialMessage = {
   type: "success",
@@ -139,16 +144,16 @@ export const initialFolderListFile = [
 ];
 // constants for upload/ImportReport
 export const initialStateImportReport = {
-  folder: "",
-  editUpload: "",
-  reportUpload: "",
-  newLicense: "licenseCanditate",
-  licenseInfoInFile: true,
-  licenseConcluded: false,
-  licenseDecision: true,
-  existingDecisions: true,
-  importDiscussed: true,
-  copyright: false,
+  folder: 1,
+  upload: "",
+  report: null,
+  addNewLicensesAs: "candidate",
+  addConcludedAsDecisions: true,
+  addLicenseInfoFromInfoInFile: true,
+  addLicenseInfoFromConcluded: false,
+  addConcludedAsDecisionsOverwrite: true,
+  addConcludedAsDecisionsTBD: true,
+  addCopyrights: false,
 };
 
 // constants for upload/UploadFromServer

--- a/src/constants/endpoints.js
+++ b/src/constants/endpoints.js
@@ -29,6 +29,7 @@ const endpoints = {
     allJobs: () => `${apiUrl}/jobs/all`,
     scheduleReport: () => `${apiUrl}/report`,
     downloadReport: (reportId) => `${apiUrl}/report/${reportId}`,
+    importReport: (uploadId) => `${apiUrl}/report/import?upload=${uploadId}`,
   },
   auth: {
     tokens: () => `${apiUrl}/tokens`,

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -1,5 +1,6 @@
 /*
  Copyright (C) 2021 Aman Dwivedi (aman.dwivedi5@gmail.com), Shruti Agarwal (mail2shruti.ag@gmail.com)
+ Copyright (C) 2022 Krishna Mahato <krishhtrishh9304@gmail.com>
 
  SPDX-License-Identifier: GPL-2.0
 
@@ -27,7 +28,7 @@ const routes = {
     server: "/upload/server",
     url: "/upload/url",
     vcs: "/upload/vcs",
-    report: "/upload/report",
+    importReport: "/upload/reportImport",
     instructions: "/upload/instructions",
     oneShotAnalysis: "/upload/oneShotAnalysis",
     oneShotCopyright: "/upload/oneShotCopyright",

--- a/src/pages/Browse/index.jsx
+++ b/src/pages/Browse/index.jsx
@@ -1,6 +1,6 @@
 /*
  Copyright (C) 2021 Shruti Agarwal (mail2shruti.ag@gmail.com), Aman Dwivedi (aman.dwivedi5@gmail.com),
- Copyright (C) 2022 Soham Banerjee (sohambanerjee4abc@hotmail.com)
+ Copyright (C) 2022 Soham Banerjee (sohambanerjee4abc@hotmail.com), Krishna Mahato (krishhtrishh9304@gmail.com)
 
  SPDX-License-Identifier: GPL-2.0
 
@@ -19,7 +19,7 @@
 
 import React, { useState, useEffect } from "react";
 import routes from "constants/routes";
-import { Link } from "react-router-dom";
+import { Link, useHistory } from "react-router-dom";
 import arrayToTree from "array-to-tree";
 import messages from "constants/messages";
 
@@ -78,6 +78,8 @@ const Browse = () => {
   // qurey used for searching in the current page
   const [query, setQuery] = useState("");
   const [pages, setPages] = useState();
+
+  const history = useHistory();
 
   useEffect(() => {
     setMessage({
@@ -146,6 +148,12 @@ const Browse = () => {
   };
 
   const handleActionChange = (e, uploadId) => {
+    if (e.target.value === "importReport") {
+      history.push(
+        `/upload/reportImport?folder=${browseData.folderId}&upload=${uploadId}`
+      );
+      return;
+    }
     scheduleReport(uploadId, e.target.value)
       .then((res) => {
         return res?.message;

--- a/src/services/jobs.js
+++ b/src/services/jobs.js
@@ -1,5 +1,6 @@
 /*
  Copyright (C) 2021 Aman Dwivedi (aman.dwivedi5@gmail.com), Shruti Agarwal (mail2shruti.ag@gmail.com)
+ Copyright (C) 2022 Krishna Mahato (krishhtrishh9304@gmail.com)
 
  SPDX-License-Identifier: GPL-2.0
 
@@ -23,6 +24,7 @@ import {
   downloadReportApi,
   getAllJobApi,
   getAllAdminJobApi,
+  importReportApi,
 } from "api/jobs";
 import { getReportIdFromUrl } from "shared/helper";
 import { getLocalStorage } from "shared/storageHelper";
@@ -77,6 +79,12 @@ export const downloadReport = (url) => {
     return null;
   }
   return downloadReportApi(reportId).then((res) => {
+    return res;
+  });
+};
+
+export const importReport = (uploadId, reqBody) => {
+  return importReportApi(uploadId, reqBody).then((res) => {
     return res;
   });
 };


### PR DESCRIPTION
Signed-off-by: Krishna Mahato <krishhtrishh9304@gmail.com>

## Description
Importing an existing report to an upload functionality is now implemented. 

The page is available from 2 places in the UI
1. In the navbar, Go to `Upload > Import Report`.
2. Directly from the browse page. Choose the upload and select `Import Report` option from the actions dropdown.

Tasks completed ---
- [x] Added logical components to the `Import Report` page
- [x] Integrated the API from https://github.com/fossology/fossology/pull/2317
- [x] Tested Everything.

## Working demo

https://user-images.githubusercontent.com/71918441/190134484-0aa5ee23-632c-4724-8467-b50fef1bba21.mp4

This fixes #264 .
cc: @GMishx @Shruti3004 @shaheemazmalmmd 