### PR TITLE
Unsupported --save during npm packages installation removed in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ docker-compose logs  #To view server logs
 npm packages can be installed using `docker-compose exec`
 
 ```zsh
-docker-compose -f docker-compose.dev.yml exec -w /usr/src/fossologyui fossologyui_server yarn add --save <package name> #Install npm package for react-dev-server
+docker-compose -f docker-compose.dev.yml exec -w /usr/src/fossologyui fossologyui_server yarn add <package name> #Install npm package for react-dev-server
 ```
 
 Once done developing, you can clean up running containers and networks using:


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/FOSSologyUI/blob/main/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Running the below command while setting up the project on local machine, I got some error related to [this](https://stackoverflow.com/questions/64131790/yarn-add-raise-error-missing-list-of-packages-to-add-to-your-project).

```zsh
docker-compose -f docker-compose.dev.yml exec -w /usr/src/fossologyui fossologyui_server yarn add --save <package name> #Install npm package for react-dev-server
```

It says that --save flag is unsupported by yarn.

### Changes

In the Readme.md file in the root directory, removed the --save flag and it worked.
