### PR TITLE
fix: UI bug at footer #266

### DIFF
--- a/src/components/Footer/index.jsx
+++ b/src/components/Footer/index.jsx
@@ -44,8 +44,8 @@ const Footer = () => {
       id="footer"
     >
       Version: [{version?.version}], Branch: [{version?.branchName}], Commit: [
-      {`#${version?.commitHash}`}] {version?.commitDate} built @{" "}
-      {version?.buildDate}
+      {`${version?.commitHash === undefined ? "" : `#${version?.commitHash}`}`}]{" "}
+      {version?.commitDate} built @ {version?.buildDate}
     </footer>
   );
 };


### PR DESCRIPTION
closes #266 

## Description

This fixes #266 UI bug at footer by showing empty string instead of undefined in footer
![Screenshot from 2023-08-13 21-20-00](https://github.com/fossology/FOSSologyUI/assets/100865986/3864a04b-79ea-440c-b729-60ba69aa4028)
### Changes

I've changed index file in Footer to conditionally check if value is undefined then show empty string instead of undefined else show the commit hash by appending # with commit
![Screenshot from 2023-08-13 21-20-16](https://github.com/fossology/FOSSologyUI/assets/100865986/6e6686be-e9d6-42df-bddd-453c16ddf753)

## How to test

to test just use yarn start and look at the footer

