### PR TITLE
Add type definition and handle JSON parsing in getLocalStorage

### DIFF
--- a/src/shared/storageHelper.js
+++ b/src/shared/storageHelper.js
@@ -20,7 +20,7 @@ import cookie from "js-cookie";
 
 // Set in cookie
 export const setCookie = (key, value) => {
-  if (window !== "undefined") {
+  if (typeof window !== "undefined") {
     cookie.set(key, value, {
       expires: 1,
       sameSite: "strict",
@@ -31,7 +31,7 @@ export const setCookie = (key, value) => {
 
 // Remove from cookie
 export const removeCookie = (key) => {
-  if (window !== "undefined") {
+  if (typeof window !== "undefined") {
     cookie.remove(key, {
       expires: 1,
     });
@@ -40,7 +40,7 @@ export const removeCookie = (key) => {
 
 // Get from cookie
 export const getCookie = (key) => {
-  if (window !== "undefined") {
+  if (typeof window !== "undefined") {
     return cookie.get(key);
   }
   return null;
@@ -56,7 +56,13 @@ export const setLocalStorage = (key, value) => {
 // Get from localstorage
 export const getLocalStorage = (key) => {
   if (typeof window !== "undefined") {
-    return JSON.parse(localStorage.getItem(key));
+    try {
+      const item = localStorage.getItem(key);
+      return item ? JSON.parse(item) : null;
+    } catch (error) {
+      return null;
+    }
+    // return JSON.parse(localStorage.getItem(key));
   }
   return null;
 };


### PR DESCRIPTION
## Description

Fixed a bug in the `getLocalStorage` function where `JSON.parse(null)` could be called unnecessarily, leading to potential issues. Now, the function first checks if the value exists before parsing.

### Changes
# storagehelper.js
- Added a null check before calling `JSON.parse(item)`.
- Moved `key-data checking` inside the `try` block after validation.
- Added better error handling .
- Added `typeof` checks in various places where it was missing


![Screenshot from 2025-03-02 15-26-25](https://github.com/user-attachments/assets/11b61261-0864-47ff-9347-34969ca900e7)


- that why , the landing page in not visible in production and in development  mode too






## How to test


1. Open the application and store a valid JSON string in `localStorage`:
   ```js
   localStorage.setItem("test", JSON.stringify({ name: "Fossology" }));
   ```
2. Call `getLocalStorage("test")` and verify that it returns `{ name: "Fossology" }`.
3. Remove the `test` key and call `getLocalStorage("test")`, ensuring it returns `null` without errors.



