### PR TITLE
fix: wrap client components with Suspense to resolve CSR bailout warnings (closes #320)

### DIFF
--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -1,6 +1,10 @@
 // Server component
-import HomeClient from './HomeClient/HomeClient';
+import dynamic from 'next/dynamic';
 import { Suspense } from 'react';
+
+const HomeClient = dynamic(() => import('./HomeClient/HomeClient'), {
+  suspense: true,
+});
 
 export const metadata = {
   title: 'Home | FOSSology',
@@ -8,7 +12,8 @@ export const metadata = {
 
 export default function HomePage() {
   return (
-    <Suspense>
+
+    <Suspense fallback={<div>Loading...</div>}>
       <HomeClient />
     </Suspense>
   );

--- a/src/app/upload/reportImport/page.jsx
+++ b/src/app/upload/reportImport/page.jsx
@@ -1,14 +1,20 @@
-import ImportReportClient from "./ReportImportClient";
-import { Suspense } from 'react';
+import dynamic from "next/dynamic";
+import { Suspense } from "react";
+
+const ReportImportClient = dynamic(() => import("./ReportImportClient"), {
+  suspense: true,
+});
+
 
 export const metadata = {
-    title: "Report Import | FOSSology",
+  title: "Report Import | FOSSology",
 };
 
 export default function ImportReportPage() {
   return (
-    <Suspense>
-      <ImportReportClient />
+
+    <Suspense fallback={<div>Loading report import...</div>}>
+      <ReportImportClient />
     </Suspense>
   );
 }


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/FOSSologyUI/blob/main/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Fixes issue #320 by properly wrapping client components that use `useSearchParams` in `<Suspense>` boundaries when rendered from server components.

### Changes

- Dynamically imported the following client components with `suspense: true`:
  - `HomeClient`
  - `ReportImportClient`
- Wrapped each dynamic import in a `<Suspense>` boundary with fallback UI.

### Why

Next.js throws hydration warnings when client-only hooks like `useSearchParams` are used without being suspended properly in a server-rendered tree. This change avoids CSR bailout and follows Next.js best practices for App Router.

### Reference

Closes #320  
[Next.js CSR Bailout Warning Docs](https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout)

<!-- Please consider using the closing keyword if the pull request is proposed to
fix an issue already created in the repository
(https://help.github.com/articles/closing-issues-using-keywords/) -->