### PR TITLE
Fix: Add ARM64 support for docker-compose.dev.yml and add start-dev.s…

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,23 +1,5 @@
 # FOSSology docker-compose file
-
-#  Copyright (C) 2022 Vineet Vatsal (vineetvatsal09@gmail.com)
-
-#  SPDX-License-Identifier: GPL-2.0
-
-#  This program is free software; you can redistribute it and/or
-#  modify it under the terms of the GNU General Public License
-#  version 2 as published by the Free Software Foundation.
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
-# Description: docker-compose file for development environment.
-
+# Development environment for FOSSologyUI (Next.js + pnpm)
 
 version: "3.9"
 
@@ -27,39 +9,43 @@ services:
       context: .
       dockerfile: Dockerfile.dev
       args:
-        - NEXT_PUBLIC_SERVER_URL=localhost/repo/api/v2
+        - NEXT_PUBLIC_SERVER_URL=http://localhost/repo/api/v2
         - NEXT_PUBLIC_HTTPS=false
-    image: fossologyui:react1.0
+    image: fossologyui:dev
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
+
     environment:
-      - NEXT_PUBLIC_SERVER_URL=localhost/repo/api/v2
+      - NEXT_PUBLIC_SERVER_URL=http://localhost/repo/api/v2
       - NEXT_PUBLIC_HTTPS=false
-    command: ../node_modules/.bin/react-scripts start
+
+    # ✅ Correct command for Next.js dev server
+    command: ["pnpm", "dev"]
+
     ports:
       - "3000:3000"
+
     volumes:
-      - .:/usr/src/fossologyui/app:delegated
-      # bind-mounting these three files in will let you add packages during development without rebuilding
-      # for example, to add bower to your app while developing, just install it inside the container
-      # and then nodemon will restart. Your changes will last until you "docker-compose down" and will
-      # be saved on host for next build
-      # NOTE: this won't work on Docker Toolbox (virtualbox) which doesn't bind-mount single files
-      # docker-compose exec node npm install --save bower
+      # Mount project root into the container as app/
+      - .:/usr/src/fossologyui:delegated
+      
+      # Mount package files so pnpm install works inside container
       - ./package.json:/usr/src/fossologyui/package.json
       - ./pnpm-lock.yaml:/usr/src/fossologyui/pnpm-lock.yaml
-      # this is a workaround to prevent host node_modules from accidently getting mounted in container
-      # in case you want to use node/npm both outside container for test/lint etc. and also inside container
-      # this will overwrite the default node_modules dir in container so it won't conflict with our
-      # /usr/src/fossologyui/node_modules location.
+
+      # Prevent your host node_modules from overwriting container node_modules
       - notused:/usr/src/fossologyui/node_modules
 
   fossology_server:
     image: fossology/fossology:latest
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
+
     ports:
       - "8081:80"
+      
     volumes:
       - repository:/srv/fossology/repository/
       - database:/var/lib/postgresql/data
-    
+
 volumes:
   notused:
   repository:

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+ARCH=$(uname -m)
+
+if [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ]; then
+  echo "Detected Apple Silicon ARM64 — enabling amd64 emulation..."
+  export DOCKER_PLATFORM="linux/amd64"
+else
+  echo "Detected x86_64 architecture."
+fi
+
+docker-compose -f docker-compose.dev.yml pull fossology_server
+docker-compose -f docker-compose.dev.yml up


### PR DESCRIPTION

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/FOSSologyUI/blob/main/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

FIXES #308 

This Pull Request adds proper ARM64 (Apple Silicon) support to the FOSSologyUI development environment.
Previously, the development setup failed on Apple Silicon machines because Docker pulled the wrong architecture image (linux/arm64), while the FOSSology backend only supports linux/amd64.


Please describe the changes in your pull request in few words here.

### Changes
 1. Adds platform emulation support
In docker-compose.dev.yml, the backend service now specifies: platform: ${DOCKER_PLATFORM:-linux/amd64}
This ensures:
	•	x86_64 users = no change
	•	ARM64 users = automatic use of linux/amd64 via emulation (QEMU)

✔️ 2. Adds start-dev.sh script

New helper script that:
	•	Detects CPU architecture (arm64 vs x86_64)
	•	Sets DOCKER_PLATFORM=linux/amd64 automatically for Apple Silicon
	•	Runs the correct docker-compose commands

This improves the developer experience and prevents architecture errors.

List the changes done to fix a bug or introducing a new feature.

## How to test

Testing was completed following project guidelines:
	1.	ARM64 (Apple Silicon) Testing
	•	./start-dev.sh correctly detected ARM64.
	•	docker-compose.dev.yml successfully pulled linux/amd64 images.
	•	UI accessible at http://localhost:3000.
	•	Backend responding correctly on port 8081.
	2.	Manual architecture override
	        DOCKER_PLATFORM=linux/amd64 docker-compose -f docker-compose.dev.yml up
        3.	Lint & build tests
	•	npm install
	•	npm run lint
	4.	Verified no unnecessary files were included
(.pnpm-store and other local folders not committed)

This improves the developer experience and prevents architecture errors.

Describe the steps required to test the changes proposed in the pull request.
How to Test
	1.	Checkout the PR branch
	       git fetch origin <branch-name>
               git checkout <branch-name>
       2.   Run the updated dev setup script
            chmod +x start-dev.sh
            ./start-dev.sh
       This will auto-detect system architecture (ARM64/x86_64) and apply the correct Docker platform.
       	3.	Verify containers start correctly
	•	UI should run on http://localhost:3000
	•	Backend fossology_server should run on http://localhost:8081
	4.	For ARM64 (Apple Silicon) users:
                Confirm backend runs using linux/amd64 emulation:
           docker inspect fossologyui_server | grep Architecture
       5.	Stop the environment
            docker compose -f docker-compose.dev.yml down

Please consider using the closing keyword if the pull request is proposed to
fix an issue already created in the repository
(https://help.github.com/articles/closing-issues-using-keywords/)