### PR TITLE
Fix: auto-hide login error alert after timeout

### DIFF
--- a/src/app/HomeClient/HomeClient.jsx
+++ b/src/app/HomeClient/HomeClient.jsx
@@ -83,6 +83,13 @@ export default function HomeClient() {
     }
   }, [searchParams, router]);
 
+  useEffect(() => {
+    if (showError) {
+      const timer = setTimeout(() => setShowError(false), 4000);
+      return () => clearTimeout(timer);
+    }
+  }, [showError]);
+
   const [showPassword, setShowPassword] = useState(false)
 
   return (


### PR DESCRIPTION
Fixes #154

This PR adds an auto-hide timeout for login error alerts so they automatically dismiss after a short duration.
