### PR TITLE
Fix: Auto-hide error snackbar after 5 seconds (Closes #154)

### DIFF
--- a/src/app/HomeClient/HomeClient.jsx
+++ b/src/app/HomeClient/HomeClient.jsx
@@ -74,6 +74,17 @@ export default function HomeClient() {
     }
   };
 
+  // --- BUG FIX: Auto-hide error after 5 seconds ---
+  useEffect(() => {
+    if (showError) {
+      const timer = setTimeout(() => {
+        setShowError(false);
+      }, 5000);
+      return () => clearTimeout(timer);
+    }
+  }, [showError]);
+  // ------------------------------------------------
+
   useEffect(() => {
     const message = searchParams.get('message');
     if (message) {


### PR DESCRIPTION
### Description
Currently, the error snackbar (alert) on the login screen persists indefinitely until the user manually closes it. This can block other UI elements and creates a friction point in the user experience.

### Changes
- Added a `useEffect` hook in `HomeClient.jsx` to handle the `showError` state.
- Implemented a 5-second timer to automatically dismiss the alert.
- Added cleanup logic to clear the timeout if the component unmounts or the state changes early.

### Related Issue
Closes #154