### PR TITLE
fix: handle non-JSON values in getLocalStorage

### DIFF
--- a/src/shared/storageHelper.js
+++ b/src/shared/storageHelper.js
@@ -57,7 +57,13 @@ export const setLocalStorage = (key, value) => {
 // Get from localstorage
 export const getLocalStorage = (key) => {
   if (typeof window !== "undefined") {
-    return JSON.parse(localStorage.getItem(key));
+    const item = localStorage.getItem(key);
+    if (item === null) return null;
+    try {
+      return JSON.parse(item);
+    } catch (error) {
+      return item;
+    }
   }
   return null;
 };


### PR DESCRIPTION
### Description
This PR fixes a JSON parsing error in the `getLocalStorage` helper function that occurs when `localStorage` contains non-JSON values.

I discovered this issue while setting up the project locally. The theme value (`"dark"`) is stored as a plain string, but the helper function attempts to parse it as JSON, resulting in a runtime error.

### What Changed
- Updated `getLocalStorage` to safely handle non-JSON values
- Added a `try/catch` around `JSON.parse`
- Falls back to returning the raw string if parsing fails

### Why This Is Needed
Not all `localStorage` values are JSON-serialized. This change prevents crashes and makes the helper more robust and flexible.

### Code Changes
```diff
function getLocalStorage(key) {
  const value = localStorage.getItem(key);
  if (!value) return null;

- return JSON.parse(value);
+ try {
+   return JSON.parse(value);
+ } catch (error) {
+   return value;
+ }
}
```

Closing #356 