### PR TITLE
Fix: Convert authentication request payload to camelCase for backend

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -36,9 +36,9 @@ const fetchTokenApi = (username, password, tokenDetails = null) => {
     body: tokenDetails || {
       username,
       password,
-      token_name: randomString(tokenNameLength),
-      token_scope: tokenScope,
-      token_expire: getDate(tokenExpiryDays),
+      tokenName: randomString(tokenNameLength),
+      tokenScope: tokenScope,
+      tokenExpire: getDate(tokenExpiryDays),
     },
     addGroupName: false,
   });

--- a/src/api/auth.test.js
+++ b/src/api/auth.test.js
@@ -39,9 +39,9 @@ describe("auth", () => {
         body: {
           username,
           password,
-          token_name: randomString,
-          token_scope: tokenScope,
-          token_expire: getDate(tokenExpiryDays),
+          tokenName: randomString,
+          tokenScope: tokenScope,
+          tokenExpire: getDate(tokenExpiryDays),
         },
         addGroupName: false,
       })


### PR DESCRIPTION
## Description

Updated  the authentication module to use camelCase property names in the token request payload to match the backend API's requirements.

### Changes

- Modified `auth.js` to use `tokenExpire` (camelCase) instead of `token_expire` (snake_case) when constructing the token request body.
- Updated `auth.test.js` test assertions to verify the corrected camelCase property names in the token payload.

## How to test
It occurs everytime you try to set up the project and run it locally.