### PR TITLE
Fix Docker dev startup failure by replacing react-scripts with next dev 

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -33,7 +33,7 @@ services:
     environment:
       - NEXT_PUBLIC_SERVER_URL=localhost/repo/api/v2
       - NEXT_PUBLIC_HTTPS=false
-    command: ../node_modules/.bin/react-scripts start
+    command: next dev
     ports:
       - "3000:3000"
     volumes:


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/FOSSologyUI/blob/main/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

This PR fixes a development environment issue where the fossologyui_server container fails to start due to a missing react-scripts dependency.

The Docker setup currently runs:

`../node_modules/.bin/react-scripts start`

However, the project uses Next.js, and react-scripts is not part of the dependencies. This causes the container to fail with:

`Error: Cannot find module '/usr/src/fossologyui/node_modules/.bin/react-scripts'`

To resolve this, the startup command has been updated to use the appropriate Next.js development server:

`next dev`

This aligns the Docker development setup with the project's framework and allows the UI container to start successfully.

### Changes

Updated the Docker development command:

**Before**:

`../node_modules/.bin/react-scripts start`

**After**:

`next dev`

This ensures the development server runs correctly for the Next.js-based UI.

## How to test

Clone the repository

Run the development environment

`docker-compose up --build`

Verify that:

`docker-compose -f docker-compose.dev.yml pull fossology_server && docker-compose -f docker-compose.dev.yml up` starts successfully

Next.js development server runs correctly

UI becomes accessible on:

`http://localhost:3000`


Closes [#368](https://github.com/fossology/FOSSologyUI/issues/368)