### PR TITLE
Fix/remove use client layout

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -33,7 +33,7 @@ services:
     environment:
       - NEXT_PUBLIC_SERVER_URL=localhost/repo/api/v2
       - NEXT_PUBLIC_HTTPS=false
-    command: ../node_modules/.bin/react-scripts start
+    command: next dev
     ports:
       - "3000:3000"
     volumes:

--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -15,9 +15,6 @@ SPDX-License-Identifier: GPL-2.0-only
  with this program; if not, write to the Free Software Foundation, Inc.,
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
-
-"use client";
-
 import React from "react";
 import { GlobalProvider } from "@/context";
 

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -15,7 +15,7 @@ SPDX-License-Identifier: GPL-2.0-only
  with this program; if not, write to the Free Software Foundation, Inc.,
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
-
+'use client';
 import { useState, useEffect } from "react";
 import { getFossologyVersion } from "@/services/info";
 import { getSessionStorage, setSessionStorage } from "@/shared/storageHelper";


### PR DESCRIPTION
## Description

In the current codebase, the `/src/app/layout.jsx` file is marked with the `"use client"` directive. However, according to Next.js best practices, layout components should remain Server Components by default.

Using `"use client"` in the root layout forces all nested components to be rendered on the client side, which can negatively affect performance, SEO, and Largest Contentful Paint (LCP).

## Changes Made

- Removed `"use client"` from `/src/app/layout.jsx`
- Kept the layout as a Server Component
- Added `"use client"` only to the Footer component since it requires client-side behavior

## Benefits

- Improves performance
- Better SEO
- Optimized LCP
- Aligns with Next.js architecture best practices

## Related Issue

Closes #368 #370 