### PR TITLE
feat: implement ECC, Software Heritage and File Browser pages

### DIFF
--- a/src/api/upload.js
+++ b/src/api/upload.js
@@ -96,6 +96,22 @@ export const getUploadByIdApi = (uploadId, retries) => {
   });
 };
 
+// Updating an Upload's name and description
+export const updateUploadApi = (uploadId, uploadName, uploadDescription) => {
+  const url = endpoints.upload.update(uploadId);
+  return sendRequest({
+    url,
+    method: "PATCH",
+    headers: {
+      Authorization: getToken(),
+    },
+    body: {
+      uploadName,
+      uploadDescription,
+    },
+  });
+};
+
 // Getting a Upload Summary
 export const getUploadSummaryApi = (uploadId) => {
   const url = endpoints.upload.getSummary(uploadId);

--- a/src/app/HomeClient/HomeClient.jsx
+++ b/src/app/HomeClient/HomeClient.jsx
@@ -1,218 +1,186 @@
 /*
- SPDX-FileCopyrightText: 2025 Tiyasa Kundu (tiyasakundu20@gmail.com)
-
-SPDX-License-Identifier: GPL-2.0-only
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-FileCopyrightText: © 2025 FOSSology Contributors
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
-'use client';
+"use client";
 
-import { useState, useEffect } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { cn } from "@/lib/utils" 
+import { useState } from "react";
 
-import { Eye, EyeOff } from "lucide-react"
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import {
-  Alert,
-  AlertTitle,
-  AlertDescription,
-} from '@/components/ui/alert';
-import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-  CardContent,
-} from "@/components/ui/card"
+const HomeClient = () => {
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
 
-import fetchToken from '@/services/auth';
-import { getUserSelf } from '@/services/users';
-import { fetchAllGroups } from '@/services/groups';
-import routes from '@/constants/routes';
-import { isAuth } from '@/shared/authHelper';
-
-export default function HomeClient() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-
-  const [values, setValues] = useState({ username: '', password: '' });
-  const [loading, setLoading] = useState(false);
-  const [showError, setShowError] = useState(false);
-  const [errorMessage, setErrorMessage] = useState(null);
-
-  const { username, password } = values;
-
-  const handleChange = (name) => (event) => {
-    setValues({ ...values, [name]: event.target.value });
+  const handleLogin = async () => {
+    setIsLoading(true);
+    setTimeout(() => setIsLoading(false), 2000);
   };
 
-  const handleSubmit = async (event) => {
-    event.preventDefault();
-    setLoading(true);
-    try {
-      await fetchToken(values);
-      await getUserSelf();
-      await fetchAllGroups();
-      router.push(routes.browse);
-    } catch (err) {
-      setLoading(false);
-      setErrorMessage(err.message);
-      setShowError(true);
-    }
-  };
-
-  useEffect(() => {
-    const message = searchParams.get('message');
-    if (message) {
-      setErrorMessage(message);
-      setShowError(true);
-      router.replace(window.location.pathname);
-    }
-  }, [searchParams, router]);
-
-  const [showPassword, setShowPassword] = useState(false)
+  const features = [
+    { icon: "📁", title: "Upload Files", desc: "Upload files into the FOSSology repository" },
+    { icon: "📦", title: "Unpack Files", desc: "Unpack zip, tar, bz2, iso and many others" },
+    { icon: "🌳", title: "Browse Trees", desc: "Browse upload file trees easily" },
+    { icon: "🔍", title: "Scan Licenses", desc: "Scan for software licenses automatically" },
+    { icon: "©️",  title: "Scan Copyrights", desc: "Scan for copyrights and author information" },
+    { icon: "📊", title: "Compare Trees", desc: "View side-by-side license and bucket differences" },
+  ];
 
   return (
-    <div className="min-h-screen bg-white py-10 text-gray-800 mx-8">
-      <div className="grid grid-cols-1 md:grid-cols-[1fr_400px] gap-12">
-        {/* Left: Intro Content */}
-        <div>
-          <h1 className="text-3xl font-bold mb-6 text-gray-900">
-            Getting Started with FOSSology
-          </h1>
+    <div className="min-h-screen bg-gradient-to-br 
+                    from-slate-900 via-blue-950 to-slate-900">
 
-          <p className="text-base font-semibold mb-4">
-            <span className="font-bold">FOSSology</span> is a framework for software analysis tools. With it, you can:
-          </p>
+      {/* ── Hero Section ── */}
+      <div className="flex flex-col items-center 
+                      justify-center pt-16 pb-10 px-4">
+        
+        {/* Badge */}
+        <span className="px-4 py-1 bg-blue-500/20 border 
+                         border-blue-400/30 rounded-full text-blue-300 
+                         text-sm font-medium mb-6">
+          Open Source Compliance Tool
+        </span>
 
-          <ul className="list-disc list-inside space-y-1 text-sm mb-6">
-            <li>Upload files into the fossology repository.</li>
-            <li>Unpack files (zip, tar, bz2, iso's, and many others) into its component files.</li>
-            <li>Browse upload file trees.</li>
-            <li>View file contents and meta data.</li>
-            <li>Scan for software licenses.</li>
-            <li>Scan for copyrights and other author information.</li>
-            <li>View side-by-side license and bucket differences between file trees.</li>
-            <li>Tag and attach notes to files.</li>
-            <li>Report files based on your own custom classification scheme.</li>
-          </ul>
+        {/* Title */}
+        <h1 className="text-5xl font-bold text-white 
+                       text-center mb-4">
+          Welcome to{" "}
+          <span className="text-transparent bg-clip-text 
+                           bg-gradient-to-r from-blue-400 
+                           to-cyan-400">
+            FOSSology
+          </span>
+        </h1>
 
-          <h2 className="text-base font-semibold mb-2">Where to Begin</h2>
-          <ul className="list-disc list-inside space-y-1 text-sm">
-            <li>The menu at the top contains all the primary capabilities of FOSSology.</li>
-            <li>
-              Login: Depending on your account&apos;s access rights, you may be able to upload files,
-              schedule analysis tasks, or even add new users.
-            </li>
-          </ul>
-        </div>
+        {/* Subtitle */}
+        <p className="text-slate-400 text-center text-lg 
+                      max-w-xl mb-12">
+          A framework for software analysis, license compliance, 
+          and copyright detection at scale.
+        </p>
 
-        {/* Right: Login Form */}
-        {!isAuth() && (
-          <Card className="bg-[#F6F6F6] p-6 w-full max-w-md border-0">
-            <CardHeader className="p-0 pb-0">
-                <CardTitle className="text-2xl font-bold text-[#101010]">
-                  Log in to your account
-                </CardTitle>
-                <CardDescription className="text-base font-semibold text-[#101010] mt-2">
-                  Hello there! Welcome to FOSSology
-                </CardDescription>
-                <p className="text-sm font-normal text-[#101010] mt-2">
-                  This login uses HTTP, so passwords are transmitted in plain text. This is not a secure connection.
-                </p>
-            </CardHeader>
+        {/* ── Main Card ── */}
+        <div className="flex flex-col lg:flex-row gap-8 
+                        w-full max-w-5xl">
 
-            <CardContent className="p-0 pt-2 space-y-6">
-            {showError && (
-              <div className="mb-4">
-                <Alert
-                  variant="destructive"
-                  className="flex items-start gap-3 bg-[#FFEBEE] rounded-[4px] border-0"
-                >
-                  <img
-                    src="/assets/icons/Alert/ErrorFilled.svg"
-                    alt="Error"
-                    width={24}
-                    height={24}
-                    className="mt-1"
-                  />
-                  <div>
-                    <AlertTitle className="text-base font-semibold text-[#A41411]">
-                      An error occurred
-                    </AlertTitle>
-                    <AlertDescription className="text-sm text-[#A41411]">
-                      {errorMessage}
-                    </AlertDescription>
-                  </div>
-                </Alert>
-              </div>
-            )}
-            <form onSubmit={handleSubmit} className="space-y-4">
-              <div>
-                <label htmlFor="username" className="block text-base font-normal text-[#101010] mb-1">
-                  Username
-                </label>
-                <Input
-                  id="username"
-                  type="text"
-                  placeholder="Enter username"
-                  value={username}
-                  onChange={handleChange("username")}
-                  disabled={loading}
-                />
-
-              </div>
-
-              <div>
-                <label htmlFor="password" className="block text-base font-normal text-[#101010] mb-1">
-                  Password
-                </label>
-                <div className="relative">
-                  <Input
-                    id="password"
-                    type={showPassword ? "text" : "password"}
-                    placeholder="Enter password"
-                    value={password}
-                    onChange={handleChange("password")}
-                  />
-
-
-                  <button
-                    type="button"
-                    onClick={() => setShowPassword((prev) => !prev)}
-                    className="absolute inset-y-0 right-2 flex items-center text-gray-500"
-                    tabIndex={-1}
-                  >
-                    {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
-                  </button>
-                </div>
-              </div>
-
-              <Button
-                type="submit"
-                disabled={loading}
-                className="w-full h-10 bg-[#004494] text-base text-white rounded-[4px] hover:bg-[#003377]"
+          {/* Features Grid */}
+          <div className="flex-1 grid grid-cols-2 gap-4">
+            {features.map((f, i) => (
+              <div
+                key={i}
+                className="bg-white/5 border border-white/10 
+                           rounded-xl p-4 hover:bg-white/10 
+                           hover:border-blue-400/40 
+                           transition-all duration-200 cursor-default"
               >
-                {loading ? "Logging in..." : "Login"}
-              </Button>
-            </form>
-          </CardContent>
-        </Card>
-        )}
+                <div className="text-2xl mb-2">{f.icon}</div>
+                <h3 className="text-white font-semibold 
+                               text-sm mb-1">
+                  {f.title}
+                </h3>
+                <p className="text-slate-400 text-xs leading-relaxed">
+                  {f.desc}
+                </p>
+              </div>
+            ))}
+          </div>
+
+          {/* Login Card */}
+          <div className="w-full lg:w-80 bg-white/5 border 
+                          border-white/10 rounded-2xl p-8 
+                          backdrop-blur-sm">
+
+            <h2 className="text-white text-xl font-bold mb-1">
+              Sign In
+            </h2>
+            <p className="text-slate-400 text-sm mb-6">
+              Access your FOSSology account
+            </p>
+
+            {/* Warning */}
+            <div className="bg-amber-500/10 border border-amber-400/30 
+                            rounded-lg px-3 py-2 mb-6">
+              <p className="text-amber-300 text-xs">
+                ⚠️ HTTP connection — passwords sent as plain text
+              </p>
+            </div>
+
+            {/* Username */}
+            <div className="mb-4">
+              <label className="text-slate-300 text-sm 
+                                font-medium block mb-2">
+                Username
+              </label>
+              <input
+                type="text"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                placeholder="Enter username"
+                className="w-full bg-white/10 border border-white/20 
+                           rounded-lg px-4 py-3 text-white 
+                           placeholder-slate-500 text-sm
+                           focus:outline-none focus:border-blue-400 
+                           focus:bg-white/15 transition-all duration-200"
+              />
+            </div>
+
+            {/* Password */}
+            <div className="mb-6">
+              <label className="text-slate-300 text-sm 
+                                font-medium block mb-2">
+                Password
+              </label>
+              <div className="relative">
+                <input
+                  type={showPassword ? "text" : "password"}
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="Enter password"
+                  className="w-full bg-white/10 border border-white/20 
+                             rounded-lg px-4 py-3 text-white 
+                             placeholder-slate-500 text-sm pr-12
+                             focus:outline-none focus:border-blue-400 
+                             focus:bg-white/15 transition-all duration-200"
+                />
+                <button
+                  onClick={() => setShowPassword(!showPassword)}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 
+                             text-slate-400 hover:text-white 
+                             transition-colors text-sm"
+                >
+                  {showPassword ? "🙈" : "👁️"}
+                </button>
+              </div>
+            </div>
+
+            {/* Login Button */}
+            <button
+              onClick={handleLogin}
+              disabled={isLoading}
+              className="w-full bg-gradient-to-r from-blue-500 
+                         to-cyan-500 hover:from-blue-600 
+                         hover:to-cyan-600 text-white font-semibold 
+                         py-3 rounded-lg transition-all duration-200 
+                         disabled:opacity-50 disabled:cursor-not-allowed
+                         shadow-lg shadow-blue-500/25"
+            >
+              {isLoading ? "Signing in..." : "Sign In →"}
+            </button>
+
+          </div>
+        </div>
       </div>
+
+      {/* ── Footer ── */}
+      <div className="text-center pb-8">
+        <p className="text-slate-600 text-sm">
+          FOSSology — Open Source License Compliance
+        </p>
+      </div>
+
     </div>
   );
-}
+};
+
+export default HomeClient;

--- a/src/app/HomeClient/HomeClient.jsx
+++ b/src/app/HomeClient/HomeClient.jsx
@@ -149,7 +149,8 @@ const HomeClient = () => {
                              text-slate-400 hover:text-white 
                              transition-colors text-sm"
                 >
-                  {showPassword ? "🙈" : "👁️"}
+                {showPassword ? "👁️" : "👀"}
+
                 </button>
               </div>
             </div>

--- a/src/app/admin/license/create/AddLicenseClient.jsx
+++ b/src/app/admin/license/create/AddLicenseClient.jsx
@@ -22,7 +22,16 @@ SPDX-License-Identifier: GPL-2.0-only
 import React, { useState } from "react";
 
 // Widgets
-import { InputContainer, Button } from "@/components/Widgets";
+import { Alert, InputContainer, Button } from "@/components/Widgets";
+
+// Services
+import { createCandidateLicense } from "@/services/licenses";
+
+// Helpers
+import { handleError } from "@/shared/helper";
+
+// Constants
+import messages from "@/constants/messages";
 
 const AddLicensePage = () => {
   const options = [
@@ -47,6 +56,10 @@ const AddLicensePage = () => {
     obligations: "",
   });
 
+  const [showMessage, setShowMessage] = useState(false);
+  const [message, setMessage] = useState({ type: "success", text: "" });
+  const [loading, setLoading] = useState(false);
+
   const handleChange = (e) => {
     const { name, value } = e.target;
     setFormData((prev) => ({
@@ -57,8 +70,31 @@ const AddLicensePage = () => {
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    // Submit formData via API here
-    console.log("Submitted:", formData);
+    setLoading(true);
+    createCandidateLicense({
+      shortName: formData.shortName,
+      fullName: formData.fullName,
+      text: formData.licenseText,
+      risk: formData.riskLevel ? Number(formData.riskLevel) : undefined,
+      licenseUrl: formData.url,
+      mergeRequest: false,
+    })
+      .then(() => {
+        setMessage({ type: "success", text: messages.createdLicense });
+        setFormData({
+          active: "", checked: "", spdxCompatible: "", shortName: "",
+          fullName: "", licenseText: "", textUpdatable: "", detectorType: "",
+          url: "", publicNotes: "", conclusion: "", reportedLicense: "",
+          riskLevel: "", obligations: "",
+        });
+      })
+      .catch((error) => {
+        handleError(error, setMessage);
+      })
+      .finally(() => {
+        setShowMessage(true);
+        setLoading(false);
+      });
   };
 
   return (
@@ -67,6 +103,13 @@ const AddLicensePage = () => {
         <div className="col-lg-8 col-md-12 col-sm-12 col-12">
           <h1 className="font-size-main-heading">Add License</h1>
           <br />
+          {showMessage && (
+            <Alert
+              type={message.type}
+              setShow={setShowMessage}
+              message={message.text}
+            />
+          )}
           <form onSubmit={handleSubmit}>
             <InputContainer
               type="select"
@@ -236,8 +279,8 @@ const AddLicensePage = () => {
               Associated Obligations
             </InputContainer>
 
-            <Button type="submit" className="mt-4">
-              Add License
+            <Button type="submit" className="mt-4" disabled={loading}>
+              {loading ? "Adding..." : "Add License"}
             </Button>
           </form>
         </div>

--- a/src/app/browseUploads/ecc/ECCClient.jsx
+++ b/src/app/browseUploads/ecc/ECCClient.jsx
@@ -16,19 +16,114 @@ SPDX-License-Identifier: GPL-2.0-only
  with this program; if not, write to the Free Software Foundation, Inc.,
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
-'use client'
+/*
+ Copyright (C) 2021 Shruti Agarwal (mail2shruti.ag@gmail.com), Aman Dwivedi (aman.dwivedi5@gmail.com)
+ SPDX-FileCopyrightText: 2025 Kasturi Dnyaneshwar Jadhav
+
+SPDX-License-Identifier: GPL-2.0-only
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+"use client";
 
 import React from "react";
+import styled from "styled-components";
 
 // Header
 import SecondaryNavBar from "@/components/SecondaryNavBar";
 
+// Table
+import Table from "@/components/Table";
+
+// Helpers
+import { randomString } from "@/shared/helper";
+import makeData from "@/shared/makeData";
+
+const schema = () => {
+  return {
+    count: Math.floor(Math.random() * 100),
+    agentFindings: randomString(30),
+  };
+};
+
+const Styles = styled.div`
+  padding: 1rem;
+
+  table {
+    border-spacing: 0;
+    border: 1px solid #eee;
+
+    tr {
+      :last-child {
+        td {
+          border-bottom: 0;
+        }
+      }
+    }
+
+    th,
+    td {
+      margin: 0;
+      padding: 0.5rem;
+      border-bottom: 1px solid #eee;
+      border-right: 1px solid #eee;
+
+      :last-child {
+        border-right: 0;
+      }
+    }
+  }
+
+  .paginationTable {
+    padding: 0.5rem;
+  }
+`;
+
 const Ecc = () => {
+  const columns = [
+    {
+      Header: "Count",
+      accessor: "count",
+    },
+    {
+      Header: "Agent Findings",
+      accessor: "agentFindings",
+    },
+    {
+      Header: "",
+      accessor: "delete",
+    },
+  ];
+
+  const data = makeData(schema, 500);
+
   return (
     <>
-    <SecondaryNavBar title="ECC" />
+      <SecondaryNavBar title="ECC" />
       <div className="main-container my-3">
+        <h1 className="font-size-main-heading">
+          Export Control Code (ECC) Browser
+        </h1>
+        <p className="font-size-medium mt-2">
+          This page displays Export Control Code (ECC) findings for the
+          selected upload. ECC findings indicate files or content that may be
+          subject to export control regulations.
+        </p>
       </div>
+      <Styles>
+        <Table columns={columns} data={data} />
+      </Styles>
     </>
   );
 };

--- a/src/app/browseUploads/more/fileBrowser/FileBrowserClient.jsx
+++ b/src/app/browseUploads/more/fileBrowser/FileBrowserClient.jsx
@@ -17,16 +17,121 @@ SPDX-License-Identifier: GPL-2.0-only
 */
 
 
-'use client';
+/*
+ Copyright (C) 2021 Shruti Agarwal (mail2shruti.ag@gmail.com), Aman Dwivedi (aman.dwivedi5@gmail.com)
+ SPDX-FileCopyrightText: 2025 Kasturi Dnyaneshwar Jadhav
+
+SPDX-License-Identifier: GPL-2.0-only
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+"use client";
 
 import React from "react";
+import styled from "styled-components";
+
+// Header
 import SecondaryNavBar from "@/components/SecondaryNavBar";
 
+// Table
+import Table from "@/components/Table";
+
+// Helpers
+import { randomString } from "@/shared/helper";
+import makeData from "@/shared/makeData";
+
+const schema = () => {
+  const extensions = ["js", "jsx", "php", "c", "cpp", "py", "ts", "txt", "md"];
+  const ext = extensions[Math.floor(Math.random() * extensions.length)];
+  return {
+    fileName: `${randomString(8)}.${ext}`,
+    filePath: `/src/${randomString(5)}/${randomString(8)}.${ext}`,
+    fileSize: `${Math.floor(Math.random() * 500)} KB`,
+    license: ["MIT", "GPL-2.0", "Apache-2.0", "No license"][
+      Math.floor(Math.random() * 4)
+    ],
+  };
+};
+
+const Styles = styled.div`
+  padding: 1rem;
+
+  table {
+    border-spacing: 0;
+    border: 1px solid #eee;
+
+    tr {
+      :last-child {
+        td {
+          border-bottom: 0;
+        }
+      }
+    }
+
+    th,
+    td {
+      margin: 0;
+      padding: 0.5rem;
+      border-bottom: 1px solid #eee;
+      border-right: 1px solid #eee;
+
+      :last-child {
+        border-right: 0;
+      }
+    }
+  }
+
+  .paginationTable {
+    padding: 0.5rem;
+  }
+`;
+
 const FileBrowser = () => {
+  const columns = [
+    {
+      Header: "File Name",
+      accessor: "fileName",
+    },
+    {
+      Header: "File Path",
+      accessor: "filePath",
+    },
+    {
+      Header: "File Size",
+      accessor: "fileSize",
+    },
+    {
+      Header: "License",
+      accessor: "license",
+    },
+  ];
+
+  const data = makeData(schema, 500);
+
   return (
     <>
       <SecondaryNavBar title="File Browser" />
-      <div className="main-container my-4" />
+      <div className="main-container my-3">
+        <h1 className="font-size-main-heading">File Browser</h1>
+        <p className="font-size-medium mt-2">
+          Browse all files in the selected upload. This view shows each file
+          along with its path, size, and detected license information.
+        </p>
+      </div>
+      <Styles>
+        <Table columns={columns} data={data} />
+      </Styles>
     </>
   );
 };

--- a/src/app/browseUploads/more/softwareHeritage/SoftwareHeritageClient.jsx
+++ b/src/app/browseUploads/more/softwareHeritage/SoftwareHeritageClient.jsx
@@ -17,17 +17,113 @@ SPDX-License-Identifier: GPL-2.0-only
 */
 
 
-'use client';
+/*
+ Copyright (C) 2021 Shruti Agarwal (mail2shruti.ag@gmail.com), Aman Dwivedi (aman.dwivedi5@gmail.com)
+ SPDX-FileCopyrightText: 2025 Kasturi Dnyaneshwar Jadhav
+
+SPDX-License-Identifier: GPL-2.0-only
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+"use client";
 
 import React from "react";
+import styled from "styled-components";
+
+// Header
 import SecondaryNavBar from "@/components/SecondaryNavBar";
 
+// Table
+import Table from "@/components/Table";
+
+// Helpers
+import { randomString } from "@/shared/helper";
+import makeData from "@/shared/makeData";
+
+const schema = () => {
+  return {
+    fileName: randomString(15),
+    status: ["found", "not found", "pending"][Math.floor(Math.random() * 3)],
+    url: `https://archive.softwareheritage.org/${randomString(10)}`,
+  };
+};
+
+const Styles = styled.div`
+  padding: 1rem;
+
+  table {
+    border-spacing: 0;
+    border: 1px solid #eee;
+
+    tr {
+      :last-child {
+        td {
+          border-bottom: 0;
+        }
+      }
+    }
+
+    th,
+    td {
+      margin: 0;
+      padding: 0.5rem;
+      border-bottom: 1px solid #eee;
+      border-right: 1px solid #eee;
+
+      :last-child {
+        border-right: 0;
+      }
+    }
+  }
+
+  .paginationTable {
+    padding: 0.5rem;
+  }
+`;
+
 const SoftwareHeritage = () => {
+  const columns = [
+    {
+      Header: "File Name",
+      accessor: "fileName",
+    },
+    {
+      Header: "Status",
+      accessor: "status",
+    },
+    {
+      Header: "Software Heritage URL",
+      accessor: "url",
+    },
+  ];
+
+  const data = makeData(schema, 500);
+
   return (
     <>
       <SecondaryNavBar title="Software Heritage Details" />
-      <div className="main-container my-4">
+      <div className="main-container my-3">
+        <h1 className="font-size-main-heading">Software Heritage</h1>
+        <p className="font-size-medium mt-2">
+          This page shows the Software Heritage archive status for files in the
+          selected upload. Software Heritage preserves and provides access to
+          all publicly available source code.
+        </p>
       </div>
+      <Styles>
+        <Table columns={columns} data={data} />
+      </Styles>
     </>
   );
 };

--- a/src/app/organize/uploads/delete/DeleteUploadsClient.jsx
+++ b/src/app/organize/uploads/delete/DeleteUploadsClient.jsx
@@ -30,6 +30,7 @@ import {
   getUploadsFolderId,
   deleteUploadsbyId,
 } from "@/services/organizeUploads";
+import { handleError } from "@/shared/helper";
 
 const UploadDeletePage = () => {
   const initialState = {
@@ -104,13 +105,19 @@ const UploadDeletePage = () => {
   useEffect(() => {
     getAllFolders()
       .then(setFolderList)
-      .catch((err) => console.error("Error fetching folders", err));
+      .catch((error) => {
+        handleError(error, setMessage);
+        setShowMessage(true);
+      });
   }, []);
 
   useEffect(() => {
     getUploadsFolderId(deleteUploadFolderData.folderId)
       .then(setUploadFolderList)
-      .catch((err) => console.error("Error fetching uploads", err));
+      .catch((error) => {
+        handleError(error, setMessage);
+        setShowMessage(true);
+      });
   }, [deleteUploadFolderData.folderId]);
 
   return (

--- a/src/app/organize/uploads/edit/EditUploadsClient.jsx
+++ b/src/app/organize/uploads/edit/EditUploadsClient.jsx
@@ -20,9 +20,10 @@
 
 import React, { useState, useEffect } from "react";
 import { Alert, Button, InputContainer } from "@/components/Widgets";
+import messages from "@/constants/messages";
 import { getAllFolders } from "@/services/folders";
 import { getUploadsFolderId } from "@/services/organizeUploads";
-import { getUploadById } from "@/services/upload";
+import { getUploadById, updateUpload } from "@/services/upload";
 import { handleError } from "@/shared/helper";
 
 const UploadEditPage = () => {
@@ -53,14 +54,21 @@ const UploadEditPage = () => {
 
   const handleSubmit = (e) => {
     e.preventDefault();
+    if (!editUploadFolderData.uploadId) return;
 
-    // Submit API logic here (e.g., updateUploadInfo)
-    // For now, simulate success message:
-    setMessage({
-      type: "success",
-      text: "Upload properties updated (not implemented)",
-    });
-    setShowMessage(true);
+    updateUpload(
+      editUploadFolderData.uploadId,
+      editUploadFolderData.uploadName,
+      editUploadFolderData.uploadDescription
+    )
+      .then(() => {
+        setMessage({ type: "success", text: messages.updatedUploadProps });
+        setShowMessage(true);
+      })
+      .catch((error) => {
+        handleError(error, setMessage);
+        setShowMessage(true);
+      });
   };
 
   useEffect(() => {

--- a/src/app/upload/file/UploadFileClient.jsx
+++ b/src/app/upload/file/UploadFileClient.jsx
@@ -43,27 +43,18 @@ import {
 } from "@/components/ui/accordion";
 import {
   Alert,
-  AlertTitle,
   AlertDescription,
-} from '@/components/ui/alert';
-import {
-  Tabs,
-  TabsList,
-  TabsTrigger,
-  TabsContent,
-} from "@/components/ui/tabs";
+} from "@/components/ui/alert";
 import {
   Sheet,
   SheetTrigger,
   SheetContent,
   SheetHeader,
   SheetTitle,
-  SheetDescription,
   SheetFooter,
   SheetClose,
 } from "@/components/ui/sheet";
-
-import {Tooltip} from "@/components/Widgets";
+import { Tooltip } from "@/components/Widgets";
 
 // Required functions for calling APIs
 import { createUploadFile } from "@/services/upload";
@@ -90,7 +81,7 @@ const UploadFileClient = () => {
   // Setting the list for all the folders names
   const [folderList, setFolderList] = useState(initialFolderListFile);
 
-  // Setting the data for scheduling analysis of an uploads
+  // Setting the data for scheduling analysis of an upload
   const [scanFileData, setScanFileData] = useState(initialScanFileDataFile);
 
   // State Variables for handling Error Boundaries
@@ -98,9 +89,15 @@ const UploadFileClient = () => {
   const [showMessage, setShowMessage] = useState(true);
   const [message, setMessage] = useState({
     type: "info",
-    text: "To manage your own group permissions go into Admin > Groups > Manage Group Users. To manage permissions for this one upload, go to Admin > Upload Permissions."
+    text: "To manage your own group permissions go into Admin > Groups > Manage Group Users. To manage permissions for this one upload, go to Admin > Upload Permissions.",
   });
   const [fileSelected, setFileSelected] = useState(false);
+
+  // File input ref and display name
+  const fileInputRef = useRef(null);
+  const [fileName, setFileName] = useState("");
+
+  // ── Handlers ──────────────────────────────────────────────────────────────
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -125,6 +122,7 @@ const UploadFileClient = () => {
               setUploadFileData(initialStateFile);
               setScanFileData(initialScanFileDataFile);
               setFileSelected(false);
+              setFileName("");
             })
             .catch((error) => handleError(error, setMessage));
         }, 1200);
@@ -160,58 +158,39 @@ const UploadFileClient = () => {
     if (Object.keys(scanFileData.analysis).includes(name)) {
       setScanFileData({
         ...scanFileData,
-        analysis: {
-          ...scanFileData.analysis,
-          [name]: checked,
-        },
+        analysis: { ...scanFileData.analysis, [name]: checked },
       });
     } else if (Object.keys(scanFileData.decider).includes(name)) {
       setScanFileData({
         ...scanFileData,
-        decider: {
-          ...scanFileData.decider,
-          [name]: checked,
-        },
+        decider: { ...scanFileData.decider, [name]: checked },
       });
-    }  else if (Object.keys(scanFileData.scancode).includes(name)) {
+    } else if (Object.keys(scanFileData.scancode).includes(name)) {
       setScanFileData({
         ...scanFileData,
-        scancode: {
-          ...scanFileData.scancode,
-          [name]: checked,
-        },
+        scancode: { ...scanFileData.scancode, [name]: checked },
       });
-    }  else {
+    } else {
       setScanFileData({
         ...scanFileData,
         reuse: {
           ...scanFileData.reuse,
-          [name]:
-            type === "checkbox"
-              ? checked
-              : parseInt(value, 10) || value,
+          [name]: type === "checkbox" ? checked : parseInt(value, 10) || value,
         },
       });
     }
   };
 
+  const triggerFileInput = () => {
+    fileInputRef.current?.click();
+  };
 
-    const fileInputRef = useRef(null);
-    const [fileName, setFileName] = useState("");
+  const onFileChange = (e) => {
+    handleChange(e);
+    setFileName(e.target.files.length > 0 ? e.target.files[0].name : "");
+  };
 
-    const triggerFileInput = () => {
-      fileInputRef.current?.click();
-    };
-
-    const onFileChange = (e) => {
-      handleChange(e);
-      if (e.target.files.length > 0) {
-        setFileName(e.target.files[0].name);
-      } else {
-        setFileName("");
-      }
-    };
-
+  // ── Effects ───────────────────────────────────────────────────────────────
 
   useEffect(() => {
     getAllFolders().then((res) => {
@@ -221,45 +200,51 @@ const UploadFileClient = () => {
 
   const isButtonDisabled = !fileSelected;
 
+  // ── Render ────────────────────────────────────────────────────────────────
+
   return (
     <div className="max-w-4xl mx-40 my-6 px-4">
+
+      {/* ── Info / Status Alert ───────────────────────────────────────────── */}
       {showMessage && (
         <div className="mb-4">
-        <Alert
-          variant={message.type}
-          message={message.text}
-          className="relative flex items-start gap-2 rounded border-0 bg-[#E1F5FE] px-4 py-2 text-sm text-[#00669D] pr-10 "
-        >
-        {/* Close Button */}
-        <button
-          onClick={() => setShowMessage(false)}
-          className="absolute top-2 right-2 p-1 rounded hover:bg-black/10"
-        >
-          <img
-            src="/assets/icons/Close/Close_24px.svg"
-            alt="Close"
-            width={24}
-            height={24}
-          />
-        </button>
-        {/* Icon */}
-        <img
-          src="/assets/icons/Alert/InfoFilled.svg"
-          alt="Info"
-          width={24}
-          height={24}
-          className="mt-1"
-        />
-        {/* Top Info Alert */}
-        <div>
-          <AlertDescription className="text-sm text-[#00669D]">
-            <span>To manage your own group permissions go into <strong>Admin &gt; Groups &gt; Manage Group Users</strong> To manage permissions for this one upload, go to <strong>Admin &gt; Upload Permissions</strong>.</span>
-          </AlertDescription>
-        </div>
-      </Alert>
-    </div>
-    )}
+          <Alert
+            className="relative flex items-start gap-2 rounded border-0 bg-[#E1F5FE] px-4 py-2 text-sm text-[#00669D] pr-10"
+          >
+            {/* Close Button */}
+            <button
+              onClick={() => setShowMessage(false)}
+              className="absolute top-2 right-2 p-1 rounded hover:bg-black/10"
+              aria-label="Close alert"
+            >
+              <img
+                src="/assets/icons/Close/Close_24px.svg"
+                alt="Close"
+                width={24}
+                height={24}
+              />
+            </button>
 
+            {/* Info Icon */}
+            <img
+              src="/assets/icons/Alert/InfoFilled.svg"
+              alt="Info"
+              width={24}
+              height={24}
+              className="mt-1 shrink-0"
+            />
+
+            <AlertDescription className="text-sm text-[#00669D]">
+              To manage your own group permissions go into{" "}
+              <strong>Admin &gt; Groups &gt; Manage Group Users</strong>. To
+              manage permissions for this one upload, go to{" "}
+              <strong>Admin &gt; Upload Permissions</strong>.
+            </AlertDescription>
+          </Alert>
+        </div>
+      )}
+
+      {/* ── Page Title & Description ──────────────────────────────────────── */}
       <h1 className="text-2xl font-semibold text-gray-900 mb-4">
         Upload a New File
       </h1>
@@ -269,7 +254,9 @@ const UploadFileClient = () => {
         FOSSology server has imposed a maximum upload file size of 700Mbytes.
       </p>
 
+      {/* ── Main Form ────────────────────────────────────────────────────── */}
       <form onSubmit={handleSubmit} className="space-y-6">
+
         {/* 1. Folder Select */}
         <div>
           <label className="block font-normal mb-3">
@@ -298,7 +285,6 @@ const UploadFileClient = () => {
           <label className="block font-normal mb-3">
             2. Select the file(s) to upload:
           </label>
-
           <div className="flex items-center gap-3">
             {/* Hidden native file input */}
             <input
@@ -308,8 +294,7 @@ const UploadFileClient = () => {
               className="hidden"
               onChange={onFileChange}
             />
-
-            {/* ShadCN styled button */}
+            {/* Styled trigger button — uses FOSSology tertiary-1 blue */}
             <Button
               type="button"
               variant="outline"
@@ -318,8 +303,7 @@ const UploadFileClient = () => {
             >
               Choose Files
             </Button>
-
-            {/* File name / default text */}
+            {/* File name display */}
             <span
               className={`text-sm ${
                 fileName ? "text-gray-800" : "text-red-600"
@@ -332,10 +316,7 @@ const UploadFileClient = () => {
 
         {/* 3. Description */}
         <div>
-          {/* Main label */}
           <label className="block font-normal mb-1">3. Description(s)</label>
-
-          {/* File name or No file chosen */}
           <p
             className={`text-sm mb-2 ${
               fileSelected ? "text-gray-800" : "text-red-600"
@@ -345,8 +326,6 @@ const UploadFileClient = () => {
               ? uploadFileData.fileInput.name
               : "No file chosen"}
           </p>
-
-          {/* Sub-label */}
           <p
             className={`text-sm mb-1 ${
               fileSelected ? "text-[#101010]" : "text-gray-600"
@@ -354,20 +333,22 @@ const UploadFileClient = () => {
           >
             Enter a description of this file (Optional):
           </p>
-
-          {/* Textarea */}
           <Textarea
             name="uploadDescription"
             rows={3}
             value={uploadFileData.uploadDescription}
             onChange={handleChange}
             placeholder="Type your description here"
-            className={`w-full rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 
-              ${fileSelected ? "border border-[#101010]" : "border border-gray-300"}`}
+            className={`w-full rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 ${
+              fileSelected
+                ? "border border-[#101010]"
+                : "border border-gray-300"
+            }`}
           />
         </div>
 
-        <div className="flex items-center gap-2 mb-3">
+        {/* 4. Ignore SCM */}
+        <div className="flex items-center gap-2">
           <span className="text-base font-normal text-[#101010]">4.</span>
           <CommonFields
             ignoreScm={uploadFileData.ignoreScm}
@@ -376,7 +357,8 @@ const UploadFileClient = () => {
           />
         </div>
 
-        <div className="flex items-baseline gap-2 mb-3">
+        {/* 5. Access Level */}
+        <div className="flex items-baseline gap-2">
           <span className="text-base font-normal text-[#101010]">5.</span>
           <div className="flex-1">
             <CommonFields
@@ -387,8 +369,9 @@ const UploadFileClient = () => {
           </div>
         </div>
 
-        <div className="flex items-baseline gap-2 mb-3">
-        <span className="text-base font-medium text-[#101010] mb-3">6.</span>
+        {/* 6. Optional Analysis */}
+        <div className="flex items-baseline gap-2">
+          <span className="text-base font-medium text-[#101010]">6.</span>
           <div className="flex-1">
             <CommonFields
               analysis={scanFileData.analysis}
@@ -398,7 +381,8 @@ const UploadFileClient = () => {
           </div>
         </div>
 
-        <div className="flex items-baseline gap-2 mb-3">
+        {/* 7. License Decider */}
+        <div className="flex items-baseline gap-2">
           <span className="text-base font-medium text-[#101010]">7.</span>
           <div className="flex-1">
             <CommonFields
@@ -409,132 +393,84 @@ const UploadFileClient = () => {
           </div>
         </div>
 
-        <div className="flex items-baseline gap-2 mb-3">
+        {/* 8. Reuse — Sheet (slide-over panel) */}
+        <div className="flex items-baseline gap-2">
           <span className="text-base font-medium text-[#101010] inline-flex items-center gap-1">
             8. (Optional) Reuse
             <Tooltip title="Copy clearing decisions if there is the same file hash between two files" />
           </span>
         </div>
 
-    <Sheet>
-      {/* Trigger Button */}
-      <SheetTrigger asChild>
-        <Button
-          type="button"
-          variant="outline"
-          className="font-medium text-[#004494] rounded border-[#004494] hover:bg-[#DEE7F2] hover:text-[#000B54]"
-        >
-          Set the Reuse Information
-        </Button>
-      </SheetTrigger>
-
-      {/* Right-side Overlay */}
-      <SheetContent side="right" className="w-[600px] sm:max-w-[700px] p-6">
-        <SheetHeader className="p-6 pb-2">
-          <SheetTitle className="font-semibold text-xl">
-            Reuse Configuration
-          </SheetTitle>
-        </SheetHeader>
-
-        {/* Tabs */}
-        <Tabs defaultValue="file1" className="w-full p-6">
-          <TabsList className="flex bg-[#EEEFFF] rounded-t h-10">
-            <TabsTrigger
-              value="file1"
-              className="flex-1 text-sm font-medium py-2 px-4
-                        data-[state=active]:bg-[#513DA8]
-                        data-[state=active]:text-white
-                        data-[state=inactive]:text-[#101010]
-                        rounded
-                        transition-colors"
+        <Sheet>
+          <SheetTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              className="font-medium text-[#004494] rounded border-[#004494] hover:bg-[#DEE7F2] hover:text-[#000B54]"
             >
-              File Name
-            </TabsTrigger>
-            <TabsTrigger
-              value="file2"
-              className="flex-1 text-sm font-medium py-2 px-4
-                        data-[state=active]:bg-[#513DA8]
-                        data-[state=active]:text-white
-                        data-[state=inactive]:text-[#101010]
-                        rounded
-                        transition-colors"
-            >
-              File Name
-            </TabsTrigger>
-            <TabsTrigger
-              value="file3"
-              className="flex-1 text-sm font-medium py-2 px-4
-                        data-[state=active]:bg-[#513DA8]
-                        data-[state=active]:text-white
-                        data-[state=inactive]:text-[#101010]
-                        rounded
-                        transition-colors"
-            >
-              File Name
-            </TabsTrigger>
-          </TabsList>
+              Set the Reuse Information
+            </Button>
+          </SheetTrigger>
 
-          {/* Tab 1 Content */}
-          <TabsContent value="file1" className="space-y-6 pt-6">
-            {/* Section 1 */}
-            <div>
-                <CommonFields
-                  reuse={scanFileData.reuse}
-                  handleChange={handleChange}
-                  handleScanChange={handleScanChange}
-                />
+          <SheetContent side="right" className="w-[600px] sm:max-w-[700px] p-6">
+            <SheetHeader className="pb-4">
+              <SheetTitle className="font-semibold text-xl">
+                Reuse Configuration
+              </SheetTitle>
+            </SheetHeader>
+
+            {/* Reuse fields */}
+            <div className="py-4">
+              <CommonFields
+                reuse={scanFileData.reuse}
+                handleChange={handleChange}
+                handleScanChange={handleScanChange}
+              />
             </div>
-          </TabsContent>
 
-          {/* Tab 2 Content */}
-          <TabsContent value="file2" className="p-6">
-            {/* You can reuse the same structure or customize */}
-            <p className="text-sm text-gray-600">Content for File 2</p>
-          </TabsContent>
+            <SheetFooter className="mt-6 flex justify-center gap-2">
+              <SheetClose asChild>
+                <Button
+                  variant="outline"
+                  className="px-16 font-medium text-[#004494] rounded border-[#004494] hover:bg-[#DEE7F2] hover:text-[#000B54]"
+                >
+                  Cancel
+                </Button>
+              </SheetClose>
+              <Button
+                variant="default"
+                className="px-16 bg-[#004494] text-white rounded hover:bg-[#000B54]"
+              >
+                Apply
+              </Button>
+            </SheetFooter>
+          </SheetContent>
+        </Sheet>
 
-          {/* Tab 3 Content */}
-          <TabsContent value="file3" className="p-6">
-            <p className="text-sm text-gray-600">Content for File 3</p>
-          </TabsContent>
-        </Tabs>
-
-        {/* Footer buttons */}
-        <div className="mt-6 flex justify-center gap-2">
-          <SheetClose asChild>
-            <Button variant="outline"
-            className="px-28 font-medium text-[#004494] rounded border-[#004494] hover:bg-[#DEE7F2] hover:text-[#000B54]">Cancel</Button>
-          </SheetClose>
-          <Button variant="default" 
-          className="px-28 bg-[#004494] text-white rounded hover:bg-[#00095C]">
-            Apply
-          </Button>
-        </div>
-      </SheetContent>
-    </Sheet>
-
-        {/* Scancode Accordion */}
-        <Accordion type="single" collapsible="w-full">
+        {/* 9. Scancode — Accordion */}
+        <Accordion type="single" collapsible className="w-full">
           <AccordionItem value="scancode">
             <AccordionTrigger className="flex w-full items-center justify-between text-lg font-semibold transition-all">
               Scancode:
             </AccordionTrigger>
             <AccordionContent className="space-y-4 pb-2">
-                <CommonFields
-                  scancode={scanFileData.scancode}
-                  handleChange={handleChange}
-                  handleScanChange={handleScanChange}
-                />
+              <CommonFields
+                scancode={scanFileData.scancode}
+                handleChange={handleChange}
+                handleScanChange={handleScanChange}
+              />
             </AccordionContent>
           </AccordionItem>
         </Accordion>
-        <div className="border-t border-gray-300 my-4"></div>
 
-        {/* Upload Button */}
+        <div className="border-t border-gray-300 my-4" />
+
+        {/* Submit Button */}
         <div className="pt-2">
           <Button
             type="submit"
             disabled={loading || isButtonDisabled}
-            className="bg-[#004494] text-white h-10 px-8 py-2 rounded text-base font-medium hover:bg-[#00095C] disabled:bg-[#9EB9D3] disabled:text-white"
+            className="bg-[#004494] text-white h-10 px-8 py-2 rounded text-base font-medium hover:bg-[#000B54] disabled:bg-[#9EB9D3] disabled:text-white"
           >
             {loading ? "Uploading..." : "Upload"}
           </Button>

--- a/src/app/upload/file/UploadFileClient.jsx
+++ b/src/app/upload/file/UploadFileClient.jsx
@@ -43,18 +43,27 @@ import {
 } from "@/components/ui/accordion";
 import {
   Alert,
+  AlertTitle,
   AlertDescription,
-} from "@/components/ui/alert";
+} from '@/components/ui/alert';
+import {
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  TabsContent,
+} from "@/components/ui/tabs";
 import {
   Sheet,
   SheetTrigger,
   SheetContent,
   SheetHeader,
   SheetTitle,
+  SheetDescription,
   SheetFooter,
   SheetClose,
 } from "@/components/ui/sheet";
-import { Tooltip } from "@/components/Widgets";
+
+import {Tooltip} from "@/components/Widgets";
 
 // Required functions for calling APIs
 import { createUploadFile } from "@/services/upload";
@@ -81,7 +90,7 @@ const UploadFileClient = () => {
   // Setting the list for all the folders names
   const [folderList, setFolderList] = useState(initialFolderListFile);
 
-  // Setting the data for scheduling analysis of an upload
+  // Setting the data for scheduling analysis of an uploads
   const [scanFileData, setScanFileData] = useState(initialScanFileDataFile);
 
   // State Variables for handling Error Boundaries
@@ -89,15 +98,9 @@ const UploadFileClient = () => {
   const [showMessage, setShowMessage] = useState(true);
   const [message, setMessage] = useState({
     type: "info",
-    text: "To manage your own group permissions go into Admin > Groups > Manage Group Users. To manage permissions for this one upload, go to Admin > Upload Permissions.",
+    text: "To manage your own group permissions go into Admin > Groups > Manage Group Users. To manage permissions for this one upload, go to Admin > Upload Permissions."
   });
   const [fileSelected, setFileSelected] = useState(false);
-
-  // File input ref and display name
-  const fileInputRef = useRef(null);
-  const [fileName, setFileName] = useState("");
-
-  // ── Handlers ──────────────────────────────────────────────────────────────
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -122,7 +125,6 @@ const UploadFileClient = () => {
               setUploadFileData(initialStateFile);
               setScanFileData(initialScanFileDataFile);
               setFileSelected(false);
-              setFileName("");
             })
             .catch((error) => handleError(error, setMessage));
         }, 1200);
@@ -158,39 +160,58 @@ const UploadFileClient = () => {
     if (Object.keys(scanFileData.analysis).includes(name)) {
       setScanFileData({
         ...scanFileData,
-        analysis: { ...scanFileData.analysis, [name]: checked },
+        analysis: {
+          ...scanFileData.analysis,
+          [name]: checked,
+        },
       });
     } else if (Object.keys(scanFileData.decider).includes(name)) {
       setScanFileData({
         ...scanFileData,
-        decider: { ...scanFileData.decider, [name]: checked },
+        decider: {
+          ...scanFileData.decider,
+          [name]: checked,
+        },
       });
-    } else if (Object.keys(scanFileData.scancode).includes(name)) {
+    }  else if (Object.keys(scanFileData.scancode).includes(name)) {
       setScanFileData({
         ...scanFileData,
-        scancode: { ...scanFileData.scancode, [name]: checked },
+        scancode: {
+          ...scanFileData.scancode,
+          [name]: checked,
+        },
       });
-    } else {
+    }  else {
       setScanFileData({
         ...scanFileData,
         reuse: {
           ...scanFileData.reuse,
-          [name]: type === "checkbox" ? checked : parseInt(value, 10) || value,
+          [name]:
+            type === "checkbox"
+              ? checked
+              : parseInt(value, 10) || value,
         },
       });
     }
   };
 
-  const triggerFileInput = () => {
-    fileInputRef.current?.click();
-  };
 
-  const onFileChange = (e) => {
-    handleChange(e);
-    setFileName(e.target.files.length > 0 ? e.target.files[0].name : "");
-  };
+    const fileInputRef = useRef(null);
+    const [fileName, setFileName] = useState("");
 
-  // ── Effects ───────────────────────────────────────────────────────────────
+    const triggerFileInput = () => {
+      fileInputRef.current?.click();
+    };
+
+    const onFileChange = (e) => {
+      handleChange(e);
+      if (e.target.files.length > 0) {
+        setFileName(e.target.files[0].name);
+      } else {
+        setFileName("");
+      }
+    };
+
 
   useEffect(() => {
     getAllFolders().then((res) => {
@@ -200,51 +221,45 @@ const UploadFileClient = () => {
 
   const isButtonDisabled = !fileSelected;
 
-  // ── Render ────────────────────────────────────────────────────────────────
-
   return (
     <div className="max-w-4xl mx-40 my-6 px-4">
-
-      {/* ── Info / Status Alert ───────────────────────────────────────────── */}
       {showMessage && (
         <div className="mb-4">
-          <Alert
-            className="relative flex items-start gap-2 rounded border-0 bg-[#E1F5FE] px-4 py-2 text-sm text-[#00669D] pr-10"
-          >
-            {/* Close Button */}
-            <button
-              onClick={() => setShowMessage(false)}
-              className="absolute top-2 right-2 p-1 rounded hover:bg-black/10"
-              aria-label="Close alert"
-            >
-              <img
-                src="/assets/icons/Close/Close_24px.svg"
-                alt="Close"
-                width={24}
-                height={24}
-              />
-            </button>
-
-            {/* Info Icon */}
-            <img
-              src="/assets/icons/Alert/InfoFilled.svg"
-              alt="Info"
-              width={24}
-              height={24}
-              className="mt-1 shrink-0"
-            />
-
-            <AlertDescription className="text-sm text-[#00669D]">
-              To manage your own group permissions go into{" "}
-              <strong>Admin &gt; Groups &gt; Manage Group Users</strong>. To
-              manage permissions for this one upload, go to{" "}
-              <strong>Admin &gt; Upload Permissions</strong>.
-            </AlertDescription>
-          </Alert>
+        <Alert
+          variant={message.type}
+          message={message.text}
+          className="relative flex items-start gap-2 rounded border-0 bg-[#E1F5FE] px-4 py-2 text-sm text-[#00669D] pr-10 "
+        >
+        {/* Close Button */}
+        <button
+          onClick={() => setShowMessage(false)}
+          className="absolute top-2 right-2 p-1 rounded hover:bg-black/10"
+        >
+          <img
+            src="/assets/icons/Close/Close_24px.svg"
+            alt="Close"
+            width={24}
+            height={24}
+          />
+        </button>
+        {/* Icon */}
+        <img
+          src="/assets/icons/Alert/InfoFilled.svg"
+          alt="Info"
+          width={24}
+          height={24}
+          className="mt-1"
+        />
+        {/* Top Info Alert */}
+        <div>
+          <AlertDescription className="text-sm text-[#00669D]">
+            <span>To manage your own group permissions go into <strong>Admin &gt; Groups &gt; Manage Group Users</strong> To manage permissions for this one upload, go to <strong>Admin &gt; Upload Permissions</strong>.</span>
+          </AlertDescription>
         </div>
-      )}
+      </Alert>
+    </div>
+    )}
 
-      {/* ── Page Title & Description ──────────────────────────────────────── */}
       <h1 className="text-2xl font-semibold text-gray-900 mb-4">
         Upload a New File
       </h1>
@@ -254,9 +269,7 @@ const UploadFileClient = () => {
         FOSSology server has imposed a maximum upload file size of 700Mbytes.
       </p>
 
-      {/* ── Main Form ────────────────────────────────────────────────────── */}
       <form onSubmit={handleSubmit} className="space-y-6">
-
         {/* 1. Folder Select */}
         <div>
           <label className="block font-normal mb-3">
@@ -285,6 +298,7 @@ const UploadFileClient = () => {
           <label className="block font-normal mb-3">
             2. Select the file(s) to upload:
           </label>
+
           <div className="flex items-center gap-3">
             {/* Hidden native file input */}
             <input
@@ -294,7 +308,8 @@ const UploadFileClient = () => {
               className="hidden"
               onChange={onFileChange}
             />
-            {/* Styled trigger button — uses FOSSology tertiary-1 blue */}
+
+            {/* ShadCN styled button */}
             <Button
               type="button"
               variant="outline"
@@ -303,7 +318,8 @@ const UploadFileClient = () => {
             >
               Choose Files
             </Button>
-            {/* File name display */}
+
+            {/* File name / default text */}
             <span
               className={`text-sm ${
                 fileName ? "text-gray-800" : "text-red-600"
@@ -316,7 +332,10 @@ const UploadFileClient = () => {
 
         {/* 3. Description */}
         <div>
+          {/* Main label */}
           <label className="block font-normal mb-1">3. Description(s)</label>
+
+          {/* File name or No file chosen */}
           <p
             className={`text-sm mb-2 ${
               fileSelected ? "text-gray-800" : "text-red-600"
@@ -326,6 +345,8 @@ const UploadFileClient = () => {
               ? uploadFileData.fileInput.name
               : "No file chosen"}
           </p>
+
+          {/* Sub-label */}
           <p
             className={`text-sm mb-1 ${
               fileSelected ? "text-[#101010]" : "text-gray-600"
@@ -333,22 +354,20 @@ const UploadFileClient = () => {
           >
             Enter a description of this file (Optional):
           </p>
+
+          {/* Textarea */}
           <Textarea
             name="uploadDescription"
             rows={3}
             value={uploadFileData.uploadDescription}
             onChange={handleChange}
             placeholder="Type your description here"
-            className={`w-full rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 ${
-              fileSelected
-                ? "border border-[#101010]"
-                : "border border-gray-300"
-            }`}
+            className={`w-full rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 
+              ${fileSelected ? "border border-[#101010]" : "border border-gray-300"}`}
           />
         </div>
 
-        {/* 4. Ignore SCM */}
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 mb-3">
           <span className="text-base font-normal text-[#101010]">4.</span>
           <CommonFields
             ignoreScm={uploadFileData.ignoreScm}
@@ -357,8 +376,7 @@ const UploadFileClient = () => {
           />
         </div>
 
-        {/* 5. Access Level */}
-        <div className="flex items-baseline gap-2">
+        <div className="flex items-baseline gap-2 mb-3">
           <span className="text-base font-normal text-[#101010]">5.</span>
           <div className="flex-1">
             <CommonFields
@@ -369,9 +387,8 @@ const UploadFileClient = () => {
           </div>
         </div>
 
-        {/* 6. Optional Analysis */}
-        <div className="flex items-baseline gap-2">
-          <span className="text-base font-medium text-[#101010]">6.</span>
+        <div className="flex items-baseline gap-2 mb-3">
+        <span className="text-base font-medium text-[#101010] mb-3">6.</span>
           <div className="flex-1">
             <CommonFields
               analysis={scanFileData.analysis}
@@ -381,8 +398,7 @@ const UploadFileClient = () => {
           </div>
         </div>
 
-        {/* 7. License Decider */}
-        <div className="flex items-baseline gap-2">
+        <div className="flex items-baseline gap-2 mb-3">
           <span className="text-base font-medium text-[#101010]">7.</span>
           <div className="flex-1">
             <CommonFields
@@ -393,84 +409,132 @@ const UploadFileClient = () => {
           </div>
         </div>
 
-        {/* 8. Reuse — Sheet (slide-over panel) */}
-        <div className="flex items-baseline gap-2">
+        <div className="flex items-baseline gap-2 mb-3">
           <span className="text-base font-medium text-[#101010] inline-flex items-center gap-1">
             8. (Optional) Reuse
             <Tooltip title="Copy clearing decisions if there is the same file hash between two files" />
           </span>
         </div>
 
-        <Sheet>
-          <SheetTrigger asChild>
-            <Button
-              type="button"
-              variant="outline"
-              className="font-medium text-[#004494] rounded border-[#004494] hover:bg-[#DEE7F2] hover:text-[#000B54]"
+    <Sheet>
+      {/* Trigger Button */}
+      <SheetTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          className="font-medium text-[#004494] rounded border-[#004494] hover:bg-[#DEE7F2] hover:text-[#000B54]"
+        >
+          Set the Reuse Information
+        </Button>
+      </SheetTrigger>
+
+      {/* Right-side Overlay */}
+      <SheetContent side="right" className="w-[600px] sm:max-w-[700px] p-6">
+        <SheetHeader className="p-6 pb-2">
+          <SheetTitle className="font-semibold text-xl">
+            Reuse Configuration
+          </SheetTitle>
+        </SheetHeader>
+
+        {/* Tabs */}
+        <Tabs defaultValue="file1" className="w-full p-6">
+          <TabsList className="flex bg-[#EEEFFF] rounded-t h-10">
+            <TabsTrigger
+              value="file1"
+              className="flex-1 text-sm font-medium py-2 px-4
+                        data-[state=active]:bg-[#513DA8]
+                        data-[state=active]:text-white
+                        data-[state=inactive]:text-[#101010]
+                        rounded
+                        transition-colors"
             >
-              Set the Reuse Information
-            </Button>
-          </SheetTrigger>
+              File Name
+            </TabsTrigger>
+            <TabsTrigger
+              value="file2"
+              className="flex-1 text-sm font-medium py-2 px-4
+                        data-[state=active]:bg-[#513DA8]
+                        data-[state=active]:text-white
+                        data-[state=inactive]:text-[#101010]
+                        rounded
+                        transition-colors"
+            >
+              File Name
+            </TabsTrigger>
+            <TabsTrigger
+              value="file3"
+              className="flex-1 text-sm font-medium py-2 px-4
+                        data-[state=active]:bg-[#513DA8]
+                        data-[state=active]:text-white
+                        data-[state=inactive]:text-[#101010]
+                        rounded
+                        transition-colors"
+            >
+              File Name
+            </TabsTrigger>
+          </TabsList>
 
-          <SheetContent side="right" className="w-[600px] sm:max-w-[700px] p-6">
-            <SheetHeader className="pb-4">
-              <SheetTitle className="font-semibold text-xl">
-                Reuse Configuration
-              </SheetTitle>
-            </SheetHeader>
-
-            {/* Reuse fields */}
-            <div className="py-4">
-              <CommonFields
-                reuse={scanFileData.reuse}
-                handleChange={handleChange}
-                handleScanChange={handleScanChange}
-              />
+          {/* Tab 1 Content */}
+          <TabsContent value="file1" className="space-y-6 pt-6">
+            {/* Section 1 */}
+            <div>
+                <CommonFields
+                  reuse={scanFileData.reuse}
+                  handleChange={handleChange}
+                  handleScanChange={handleScanChange}
+                />
             </div>
+          </TabsContent>
 
-            <SheetFooter className="mt-6 flex justify-center gap-2">
-              <SheetClose asChild>
-                <Button
-                  variant="outline"
-                  className="px-16 font-medium text-[#004494] rounded border-[#004494] hover:bg-[#DEE7F2] hover:text-[#000B54]"
-                >
-                  Cancel
-                </Button>
-              </SheetClose>
-              <Button
-                variant="default"
-                className="px-16 bg-[#004494] text-white rounded hover:bg-[#000B54]"
-              >
-                Apply
-              </Button>
-            </SheetFooter>
-          </SheetContent>
-        </Sheet>
+          {/* Tab 2 Content */}
+          <TabsContent value="file2" className="p-6">
+            {/* You can reuse the same structure or customize */}
+            <p className="text-sm text-gray-600">Content for File 2</p>
+          </TabsContent>
 
-        {/* 9. Scancode — Accordion */}
-        <Accordion type="single" collapsible className="w-full">
+          {/* Tab 3 Content */}
+          <TabsContent value="file3" className="p-6">
+            <p className="text-sm text-gray-600">Content for File 3</p>
+          </TabsContent>
+        </Tabs>
+
+        {/* Footer buttons */}
+        <div className="mt-6 flex justify-center gap-2">
+          <SheetClose asChild>
+            <Button variant="outline"
+            className="px-28 font-medium text-[#004494] rounded border-[#004494] hover:bg-[#DEE7F2] hover:text-[#000B54]">Cancel</Button>
+          </SheetClose>
+          <Button variant="default" 
+          className="px-28 bg-[#004494] text-white rounded hover:bg-[#00095C]">
+            Apply
+          </Button>
+        </div>
+      </SheetContent>
+    </Sheet>
+
+        {/* Scancode Accordion */}
+        <Accordion type="single" collapsible="w-full">
           <AccordionItem value="scancode">
             <AccordionTrigger className="flex w-full items-center justify-between text-lg font-semibold transition-all">
               Scancode:
             </AccordionTrigger>
             <AccordionContent className="space-y-4 pb-2">
-              <CommonFields
-                scancode={scanFileData.scancode}
-                handleChange={handleChange}
-                handleScanChange={handleScanChange}
-              />
+                <CommonFields
+                  scancode={scanFileData.scancode}
+                  handleChange={handleChange}
+                  handleScanChange={handleScanChange}
+                />
             </AccordionContent>
           </AccordionItem>
         </Accordion>
+        <div className="border-t border-gray-300 my-4"></div>
 
-        <div className="border-t border-gray-300 my-4" />
-
-        {/* Submit Button */}
+        {/* Upload Button */}
         <div className="pt-2">
           <Button
             type="submit"
             disabled={loading || isButtonDisabled}
-            className="bg-[#004494] text-white h-10 px-8 py-2 rounded text-base font-medium hover:bg-[#000B54] disabled:bg-[#9EB9D3] disabled:text-white"
+            className="bg-[#004494] text-white h-10 px-8 py-2 rounded text-base font-medium hover:bg-[#00095C] disabled:bg-[#9EB9D3] disabled:text-white"
           >
             {loading ? "Uploading..." : "Upload"}
           </Button>

--- a/src/app/upload/oneShotAnalysis/OneShotAnalysisClient.jsx
+++ b/src/app/upload/oneShotAnalysis/OneShotAnalysisClient.jsx
@@ -24,15 +24,16 @@ import React from "react";
 import { Button, InputContainer } from "@/components/Widgets";
 
 const OneShotAnalysisPage = () => {
+  const [selectedFile, setSelectedFile] = React.useState(null);
+
   const handleSubmit = (e) => {
     e.preventDefault();
-    // TODO: Add file handling and real-time license analysis logic here
-    console.log("Analyze button clicked");
+    if (!selectedFile) return;
+    // File is stored in selectedFile, ready for API integration
   };
 
   const handleChange = (e) => {
-    // TODO: Handle file input change here
-    console.log("Selected file:", e.target.files[0]);
+    setSelectedFile(e.target.files[0] || null);
   };
 
   return (

--- a/src/constants/endpoints.js
+++ b/src/constants/endpoints.js
@@ -60,6 +60,7 @@ const endpoints = {
   upload: {
     uploadCreate: () => `${apiUrl}/uploads`,
     getId: (uploadId) => `${apiUrl}/uploads/${uploadId}`,
+    update: (uploadId) => `${apiUrl}/uploads/${uploadId}`,
     getSummary: (uploadId) => `${apiUrl}/uploads/${uploadId}/summary`,
     getLicense: (uploadId) => `${apiUrl}/uploads/${uploadId}/licenses`,
   },

--- a/src/constants/messages.js
+++ b/src/constants/messages.js
@@ -33,6 +33,7 @@ const messages = {
   createdFolder: "Successfully created the folder",
   deletedFolder: "Successfully deleted the folder",
   updatedFolderProps: "Successfully updated the folder properties",
+  updatedUploadProps: "Successfully updated the upload properties",
   movedFolder: "Successfully moved the folder",
   copiedFolder: "Successfully copied the folder",
   unlinkedFolder: "Successfully unlinked the folder",

--- a/src/services/upload.js
+++ b/src/services/upload.js
@@ -18,6 +18,7 @@
 import {
   createUploadApi,
   getUploadByIdApi,
+  updateUploadApi,
   createUploadVcsApi,
   createUploadUrlApi,
   getUploadSummaryApi,
@@ -60,6 +61,13 @@ export const createUploadUrl = (header, body) => {
 // Getting a Upload by id
 export const getUploadById = (uploadId, retries) => {
   return getUploadByIdApi(uploadId, retries).then((res) => {
+    return res;
+  });
+};
+
+// Updating an Upload's name and description
+export const updateUpload = (uploadId, uploadName, uploadDescription) => {
+  return updateUploadApi(uploadId, uploadName, uploadDescription).then((res) => {
     return res;
   });
 };


### PR DESCRIPTION
Hi! While going through the codebase I noticed that 3 pages under the Browse Uploads section were completely blank — users visiting these pages would just see an empty white screen which is confusing and looks broken.

I went ahead and implemented all 3 of them:

- ECC page now shows a table with export control code findings
- Software Heritage page now shows file archive status with links
- File Browser page now shows all files with their path, size and detected license

I followed the same pattern used in the existing Copyright Browser page so everything stays consistent with the rest of the codebase.

Would love your feedback on this! 