### PR TITLE
fix(navbar): remove redundant Home navigation link

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -93,7 +93,7 @@ export default function Header() {
 
         {/* Navigation Menu */}
         <nav className="hidden md:flex">
-          <Link href={routes.home} className={clsx("flex items-center h-13 p-4 justify-between", !isHomeActive ? "hover:border-b-2 hover:border-[#C31730] hover:font-medium" : "border-b-2 border-[#C31730] font-medium")}>Home</Link>
+          
           {isAuth() && (
             <>
               <Link href={routes.search} className={clsx("flex items-center h-13 p-4 justify-between", !isSearchActive ? "hover:border-b-2 hover:border-[#C31730] hover:font-medium" : "border-b-2 border-[#C31730] font-medium")}>Search</Link>


### PR DESCRIPTION
This PR improves navbar clarity by removing the redundant Home navigation link, since clicking the FOSSology logo already redirects users to the homepage.

Changes
Removed the Home link from the navbar
Preserved the logo as the primary navigation path to the homepage
Simplified the top navigation for a cleaner user experience
How to test
Run the application
Open the UI and view the top navigation bar
Confirm the Home button is no longer visible
Click the FOSSology logo
Verify that it still redirects to the homepage

Closes #188