### PR TITLE
fix(ssr): prevent hydration mismatches from client-only storage reads

### DIFF
--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -21,9 +21,7 @@ import { getFossologyVersion } from "@/services/info";
 import { getSessionStorage, setSessionStorage } from "@/shared/storageHelper";
 
 const Footer = () => {
-  const [version, setVersion] = useState(
-    getSessionStorage("fossologyVersion") || null
-  );
+  const [version, setVersion] = useState(null);
 
   const fetchVersion = () => {
     return getFossologyVersion()
@@ -36,7 +34,10 @@ const Footer = () => {
   };
 
   useEffect(() => {
-    if (!version) {
+    const cached = getSessionStorage("fossologyVersion");
+    if (cached) {
+      setVersion(cached);
+    } else {
       fetchVersion();
     }
   }, []);

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -46,6 +46,8 @@ import { getLocalStorage, setLocalStorage } from "@/shared/storageHelper";
 
 export default function Header() {
   const [currentGroup, setCurrentGroup] = useState(null);
+  const [authenticated, setAuthenticated] = useState(false);
+  const [groups, setGroups] = useState(null);
   const pathname = usePathname();
   const router = useRouter();
 
@@ -78,6 +80,8 @@ export default function Header() {
       getLocalStorage("currentGroup") ||
       getLocalStorage("user")?.default_group;
     setCurrentGroup(defaultGroup);
+    setAuthenticated(isAuth());
+    setGroups(getAllGroups());
   }, []);
 
   const handleGroupChange = (groupName) => {
@@ -94,7 +98,7 @@ export default function Header() {
         {/* Navigation Menu */}
         <nav className="hidden md:flex">
           <Link href={routes.home} className={clsx("flex items-center h-13 p-4 justify-between", !isHomeActive ? "hover:border-b-2 hover:border-[#C31730] hover:font-medium" : "border-b-2 border-[#C31730] font-medium")}>Home</Link>
-          {isAuth() && (
+          {authenticated && (
             <>
               <Link href={routes.search} className={clsx("flex items-center h-13 p-4 justify-between", !isSearchActive ? "hover:border-b-2 hover:border-[#C31730] hover:font-medium" : "border-b-2 border-[#C31730] font-medium")}>Search</Link>
               <Link href={routes.browse} className={clsx("flex items-center h-13 p-4 justify-between", !isBrowseActive ? "hover:border-b-2 hover:border-[#C31730] hover:font-medium" : "border-b-2 border-[#C31730] font-medium")}>Browse</Link>
@@ -473,7 +477,7 @@ export default function Header() {
       {/* Right Side Icons */}
       <div className="flex items-center gap-6 text-sm text-gray-800">
         {/* Group Dropdown */}
-        {getAllGroups() && (
+        {groups && (
           <DropdownMenu open={isGroupOpen} onOpenChange={setIsGroupOpen}>
             <DropdownMenuTrigger
               onClick={(e) => {
@@ -537,7 +541,7 @@ export default function Header() {
 
                     {isGroupSelectOpen && (
                       <div className="mt-1 border rounded-[4px] border-[#CECECE] shadow bg-white overflow-hidden">
-                        {getAllGroups().map((group) => (
+                        {groups.map((group) => (
                           <div
                             key={group.id}
                             onClick={() => {

--- a/src/shared/storageHelper.js
+++ b/src/shared/storageHelper.js
@@ -57,7 +57,9 @@ export const setLocalStorage = (key, value) => {
 // Get from localstorage
 export const getLocalStorage = (key) => {
   if (typeof window !== "undefined") {
-    return JSON.parse(localStorage.getItem(key));
+    const item = localStorage.getItem(key);
+    if (item === null || item === "undefined") return null;
+    return JSON.parse(item);
   }
   return null;
 };
@@ -98,7 +100,9 @@ export const defaultAgentsList = () => {
 // Get from session storage
 export const getSessionStorage = (key) => {
   if (typeof window !== "undefined") {
-    return JSON.parse(sessionStorage.getItem(key));
+    const item = sessionStorage.getItem(key);
+    if (item === null || item === "undefined") return null;
+    return JSON.parse(item);
   }
   return null;
 };


### PR DESCRIPTION
## Description

Fixes SSR hydration mismatches caused by browser storage being accessed during render. The server rendered fallback values (`null`/`false`), while the client immediately rendered values from storage, resulting in hydration warnings.

### Changes

#### Header

* `isAuth()` and `getAllGroups()` were previously called directly during render.
* Replaced with `authenticated` and `groups` state variables, initialized to `false` and `null`.
* Values are now populated in the existing `useEffect`, ensuring consistent server and client renders.

#### Footer

* `useState` was initialized with `getSessionStorage("fossologyVersion")`.
* Moved the storage read into `useEffect`, preserving the existing cache behavior while avoiding hydration mismatches.

#### storageHelper

* `getLocalStorage` and `getSessionStorage` could throw when attempting to parse `"undefined"` via `JSON.parse`.
* Added guards for `null` and `undefined` values before parsing.

### How to Test

1. Start the development environment:

   ```bash
   docker compose -f docker-compose.dev.yml up
   ```

2. Open:

   ```text
   http://localhost:3000
   ```

3. Open **DevTools → Console**.

4. Verify that no hydration mismatch warnings or errors appear during page load.

Closes #243.

> cc @deo002 