### PR TITLE
fix(layout): convert RootLayout to Server Component

### DIFF
--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -16,8 +16,6 @@ SPDX-License-Identifier: GPL-2.0-only
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-"use client";
-
 import React from "react";
 import { GlobalProvider } from "@/context";
 

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -16,6 +16,8 @@ SPDX-License-Identifier: GPL-2.0-only
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
+"use client";
+
 import { useState, useEffect } from "react";
 import { getFossologyVersion } from "@/services/info";
 import { getSessionStorage, setSessionStorage } from "@/shared/storageHelper";


### PR DESCRIPTION
## Description

Closes #370

The root layout was unnecessarily marked with `"use client"`, causing the entire application tree to be rendered as a Client Component. This prevents Next.js from taking advantage of Server Components and can negatively impact performance, SEO, and Largest Contentful Paint (LCP).

`GlobalProvider`, `Header`, and `Footer` already operate within client boundaries, either by declaring `"use client"` themselves or by using client-only React hooks. As a result, the root layout does not need to be a Client Component.

Since `Footer` relies on client-side functionality, it is now explicitly marked as a Client Component.

### Changes

* Remove `"use client"` from `src/app/layout.jsx`
* Add `"use client"` to `src/components/Footer/Footer.jsx`

### How to Test

1. Start the development environment:

   ```bash
   docker compose -f docker-compose.dev.yml up
   ```

2. Open:

   ```text
   http://localhost:3000
   ```

3. Verify that the application loads successfully.

4. Confirm that the footer displays the version information.

5. Open **DevTools → Console** and verify that no errors are reported.
