### PR TITLE
feat(nextjs): Implement License compatibility pages

### DIFF
--- a/src/app/admin/compatibility/CompatibilityTabsNav.jsx
+++ b/src/app/admin/compatibility/CompatibilityTabsNav.jsx
@@ -1,0 +1,51 @@
+/*
+ SPDX-FileCopyrightText: 2026 Tiyasa Kundu (tiyasakundu20@gmail.com)
+
+SPDX-License-Identifier: GPL-2.0-only
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import routes from "@/constants/routes";
+
+const compatibilityTabs = [
+  { label: "Select Compatibility Rules", href: routes.admin.compatibility.selectCompatibility},
+  { label: "Operations", href: routes.admin.compatibility.operations },
+];
+
+export default function CompatibilityTabsNav() {
+  const pathname = usePathname();
+
+  const activeTab = pathname.startsWith(
+    routes.admin.compatibility.operations
+  )
+    ? routes.admin.compatibility.operations
+    : routes.admin.compatibility.selectCompatibility;
+
+  return (
+    <Tabs value={activeTab}>
+      <TabsList>
+        {compatibilityTabs.map((tab) => (
+          <TabsTrigger key={tab.href} value={tab.href} asChild>
+            <Link href={tab.href}>{tab.label}</Link>
+          </TabsTrigger>
+        ))}
+      </TabsList>
+    </Tabs>
+  );
+}

--- a/src/app/admin/compatibility/layout.jsx
+++ b/src/app/admin/compatibility/layout.jsx
@@ -1,0 +1,29 @@
+/*
+ SPDX-FileCopyrightText: 2026 Tiyasa Kundu (tiyasakundu20@gmail.com)
+
+SPDX-License-Identifier: GPL-2.0-only
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+import CompatibilityTabsNav from "./CompatibilityTabsNav";
+
+export default function CompatibilityLayout({ children }) {
+  return (
+    <div className="mx-40 px-4">
+      <h1 className="text-2xl font-semibold text-gray-900 mt-6 mb-4">License Compatibility Rules</h1>
+      <CompatibilityTabsNav />
+      <div className="mt-6">{children}</div>
+    </div>
+  );
+}

--- a/src/app/admin/compatibility/operations/OperationsClient.jsx
+++ b/src/app/admin/compatibility/operations/OperationsClient.jsx
@@ -1,0 +1,63 @@
+/*
+ SPDX-FileCopyrightText: 2026 Tiyasa Kundu (tiyasakundu20@gmail.com)
+
+SPDX-License-Identifier: GPL-2.0-only
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import routes from "@/constants/routes";
+
+const OperationsClient = () => {
+  const router = useRouter();
+
+  const handleImport = () => {
+    router.push(routes.admin.compatibility.rulesImport);
+  };
+
+  const handleExport = () => {
+    // TODO: implement Rules Export
+  };
+
+  return (
+    <div>
+      <h1 className="text-2xl font-semibold text-gray-900 mb-6">
+        Operations
+      </h1>
+
+      <div className="flex gap-6">
+        <Button
+          type="button"
+          variant="default"
+          onClick={handleImport}
+        >
+          Rules Import
+        </Button>
+
+        <Button
+          type="button"
+          variant="default"
+          onClick={handleExport}
+        >
+          Rules Export
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default OperationsClient;

--- a/src/app/admin/compatibility/operations/page.jsx
+++ b/src/app/admin/compatibility/operations/page.jsx
@@ -1,0 +1,23 @@
+/*
+ SPDX-FileCopyrightText: 2026 Tiyasa Kundu (tiyasakundu20@gmail.com)
+
+SPDX-License-Identifier: GPL-2.0-only
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+import OperationsClient from "./OperationsClient";
+
+export default function OperationsPage() {
+  return <OperationsClient />;
+}

--- a/src/app/admin/compatibility/operations/rulesImport/RulesImportClient.jsx
+++ b/src/app/admin/compatibility/operations/rulesImport/RulesImportClient.jsx
@@ -1,0 +1,123 @@
+/*
+ SPDX-FileCopyrightText: 2026 Tiyasa Kundu (tiyasakundu20@gmail.com)
+
+SPDX-License-Identifier: GPL-2.0-only
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+"use client";
+
+import { useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import routes from "@/constants/routes";
+
+import { Button } from "@/components/ui/button";
+
+export default function RulesImportClient() {
+  const router = useRouter();
+  const [file, setFile] = useState(null);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+
+    if (!file) {
+      return;
+    }
+
+    // TODO: call Rules Import API
+  };
+
+  const handleBack = () => {
+    router.push(routes.admin.compatibility.operations);
+  };
+
+  const fileInputRef = useRef(null);
+
+  return (
+    <div>
+      <h1 className="text-2xl font-semibold text-gray-900 mb-6">
+        Operations
+      </h1>
+
+      <h2 className="text-lg font-semibold text-gray-900 mb-4">
+        Admin License Rules Import
+      </h2>
+
+      <p className="mb-6 max-w-5xl text-base text-gray-900">
+        This option permits uploading a YAML file from your computer to
+        FOSSology.
+        <br />
+        Your FOSSology server has imposed a maximum upload file size of
+        700Mbytes.
+      </p>
+
+      <form onSubmit={handleSubmit}>
+        <div className="mb-6">
+          <div>
+            <label className="block font-normal mb-3">
+              Select the YAML-file to upload:
+            </label>
+
+            <div className="flex items-end gap-3">
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".yaml,.yml"
+                className="hidden"
+                onChange={(e) => setFile(e.target.files?.[0] || null)}
+              />
+
+              <Button
+                type="button"
+                variant="outline"
+                className="font-medium text-primary rounded border-primary hover:bg-accent hover:text-accent-foreground"
+                onClick={() => fileInputRef.current?.click()}
+              >
+                Choose File
+              </Button>
+
+              <span
+                className={`self-end text-sm ${
+                  file
+                    ? "text-info-500"
+                    : "text-error-600"
+                }`}
+              >
+                {file ? file.name : "No file chosen"}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex gap-6">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleBack}
+          >
+            Back
+          </Button>
+
+          <Button
+            type="submit"
+            disabled={!file}
+          >
+            Upload
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/admin/compatibility/operations/rulesImport/page.jsx
+++ b/src/app/admin/compatibility/operations/rulesImport/page.jsx
@@ -1,0 +1,23 @@
+/*
+ SPDX-FileCopyrightText: 2026 Tiyasa Kundu (tiyasakundu20@gmail.com)
+
+SPDX-License-Identifier: GPL-2.0-only
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+import RulesImportClient from "./RulesImportClient";
+
+export default function RulesImportPage() {
+  return <RulesImportClient />;
+}

--- a/src/app/admin/compatibility/page.jsx
+++ b/src/app/admin/compatibility/page.jsx
@@ -1,0 +1,24 @@
+/*
+ SPDX-FileCopyrightText: 2026 Tiyasa Kundu (tiyasakundu20@gmail.com)
+
+SPDX-License-Identifier: GPL-2.0-only
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+import { redirect } from "next/navigation";
+import routes from "@/constants/routes";
+
+export default function CompatibilityIndexPage() {
+  redirect(routes.admin.compatibility.selectCompatibility);
+}

--- a/src/app/admin/compatibility/selectCompatibility/SelectCompatibilityClient.jsx
+++ b/src/app/admin/compatibility/selectCompatibility/SelectCompatibilityClient.jsx
@@ -1,0 +1,50 @@
+/*
+ SPDX-FileCopyrightText: 2026 Tiyasa Kundu (tiyasakundu20@gmail.com)
+
+SPDX-License-Identifier: GPL-2.0-only
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+"use client";
+
+export default function SelectCompatibilityClient() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold text-gray-900">
+          Select Compatibility Rules
+        </h2>
+
+        <p className="mt-2 text-sm text-muted-foreground">
+          License compatibility rule management will be implemented here.
+        </p>
+      </div>
+
+      <div className="rounded-md border bg-card p-6">
+        <p className="text-sm text-muted-foreground">
+          This page will contain:
+        </p>
+
+        <ul className="mt-3 list-disc pl-5 text-sm text-muted-foreground space-y-1">
+          <li>Compatibility Rules table</li>
+          <li>Rule search and filtering</li>
+          <li>Add Rule functionality</li>
+          <li>Edit Rule functionality</li>
+          <li>Delete Rule functionality</li>
+          <li>Pagination support</li>
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/compatibility/selectCompatibility/page.jsx
+++ b/src/app/admin/compatibility/selectCompatibility/page.jsx
@@ -1,0 +1,23 @@
+/*
+ SPDX-FileCopyrightText: 2026 Tiyasa Kundu (tiyasakundu20@gmail.com)
+
+SPDX-License-Identifier: GPL-2.0-only
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+import SelectCompatibilityClient from "./SelectCompatibilityClient";
+
+export default function SelectCompatibilityPage() {
+  return <SelectCompatibilityClient />;
+}

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -330,32 +330,19 @@ export default function Header({ variant = "default" }) {
                     <DropdownMenuItem asChild className="hover:font-bold focus:font-bold">
                       <Link href={routes.admin.group.index}>Groups</Link>
                     </DropdownMenuItem>
-                    <DropdownMenuSub>
-                      <DropdownMenuSubTrigger 
-                      className={clsx(
-                        "flex items-center justify-between w-full px-2 py-2 text-sm rounded-md cursor-pointer",
-                        "hover:bg-secondary hover:text-gray-900 hover:font-bold",
-                        "focus:bg-secondary focus:text-gray-900 focus:font-bold",
-                        "data-[state=open]:bg-secondary data-[state=open]:text-gray-900 data-[state=open]:font-bold"
-                      )}>License Administration
-                      </DropdownMenuSubTrigger>
-                      <DropdownMenuSubContent className="p-0 m-0 bg-white border border-gray-200">
-                        <DropdownMenuItem asChild className="focus:bg-secondary focus:text-gray-900 focus:font-bold"><Link href={""}>Acknowledgements</Link></DropdownMenuItem>
-                        <DropdownMenuItem asChild className="focus:bg-secondary focus:text-gray-900 focus:font-bold"><Link href={routes.admin.license.create}>Add License</Link></DropdownMenuItem>
-                        <DropdownMenuItem asChild className="focus:bg-secondary focus:text-gray-900 focus:font-bold"><Link href={routes.admin.license.licenseCSV}>CSV Export All</Link></DropdownMenuItem>
-                        <DropdownMenuItem asChild className="focus:bg-secondary focus:text-gray-900 focus:font-bold"><Link href={""}>CSV Export Marrydone</Link></DropdownMenuItem>
-                        <DropdownMenuItem asChild className="focus:bg-secondary focus:text-gray-900 focus:font-bold"><Link href={""}>Candidates</Link></DropdownMenuItem>
-                        <DropdownMenuItem asChild className="focus:bg-secondary focus:text-gray-900 focus:font-bold"><Link href={""}>Compatibility Rules</Link></DropdownMenuItem>
-                        <DropdownMenuItem asChild className="focus:bg-secondary focus:text-gray-900 focus:font-bold"><Link href={""}>JSON Export All</Link></DropdownMenuItem>
-                        <DropdownMenuItem asChild className="focus:bg-secondary focus:text-gray-900 focus:font-bold"><Link href={""}>JSON Export Marrydone</Link></DropdownMenuItem>
-                        <DropdownMenuItem asChild className="focus:bg-secondary focus:text-gray-900 focus:font-bold"><Link href={""}>License Import</Link></DropdownMenuItem>
-                        <DropdownMenuItem asChild className="focus:bg-secondary focus:text-gray-900 focus:font-bold"><Link href={""}>Rules Export</Link></DropdownMenuItem>
-                        <DropdownMenuItem asChild className="focus:bg-secondary focus:text-gray-900 focus:font-bold"><Link href={""}>Rules Import</Link></DropdownMenuItem>
-                        <DropdownMenuItem asChild className="focus:bg-secondary focus:text-gray-900 focus:font-bold"><Link href={routes.admin.license.selectLicense}>Select License</Link></DropdownMenuItem>
-                        <DropdownMenuItem asChild className="focus:bg-secondary focus:text-gray-900 focus:font-bold"><Link href={""}>Standard Comments</Link></DropdownMenuItem>
-                      </DropdownMenuSubContent>
-                    </DropdownMenuSub>
-                    <DropdownMenuItem asChild className="focus:bg-secondary focus:text-gray-900 focus:font-bold">
+                    <DropdownMenuItem asChild className="hover:font-bold focus:font-bold">
+                      <Link href={""}>Standard Comments</Link>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem asChild className="hover:font-bold focus:font-bold">
+                      <Link href={""}>Acknowledgements</Link>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem asChild className="hover:font-bold focus:font-bold">
+                      <Link href={routes.admin.compatibility.selectCompatibility}>Compatibility Rules</Link>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem asChild className="hover:font-bold focus:font-bold">
+                      <Link href={routes.admin.license.create}>License Administration</Link>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem asChild className="hover:font-bold focus:font-bold">
                     <Link href={routes.admin.maintenance}>Maintenance</Link>
                     </DropdownMenuItem>
                     <DropdownMenuSub>

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -79,6 +79,11 @@ const routes = {
       delete: "/admin/users/delete",
       edit: "/admin/users/edit",
     },
+    compatibility:{
+      selectCompatibility: "/admin/compatibility/selectCompatibility",
+      operations: "/admin/compatibility/operations",
+      rulesImport: "/admin/compatibility/operations/rulesImport",
+    },
     license: {
       create: "/admin/license/create",
       selectLicense: "/admin/license/selectLicense",


### PR DESCRIPTION
## Description

Implement license compatibility pages

### Changes

- Implement license compatibility pages which include:
   - License Compatibility page with the tabs nav bar
   - Operations page -> Rules Import and Rules Export Buttons (missing api yet to be implemented)
   - Rules Import page
   
Related #401 