### PR TITLE
feat(nextjs): Implement Obligation Admin Pages

### DIFF
--- a/src/api/obligation.js
+++ b/src/api/obligation.js
@@ -1,0 +1,135 @@
+/*
+ SPDX-FileCopyrightText: 2026 Tiyasa Kundu (tiyasakundu20@gmail.com)
+
+SPDX-License-Identifier: GPL-2.0-only
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+import endpoints from "@/constants/endpoints";
+import { getToken } from "@/shared/authHelper";
+import sendRequest from "./sendRequest";
+
+// Get list of obligations (id + topic)
+export const getObligationsListApi = () => {
+    return sendRequest({
+        url: endpoints.obligations.getList(),
+        method: "GET",
+        headers: {
+        Authorization: getToken(),
+        },
+    });
+};
+
+
+// Get all obligation details
+export const getAllObligationsApi = () => {
+    return sendRequest({
+        url: endpoints.obligations.getAll(),
+        method: "GET",
+        headers: {
+        Authorization: getToken(),
+        },
+    });
+};
+
+
+// Get obligation by id
+export const getObligationByIdApi = (id) => {
+    return sendRequest({
+        url: endpoints.obligations.getById(id),
+        method: "GET",
+        headers: {
+        Authorization: getToken(),
+        },
+    });
+};
+
+//Create obligation
+export const createObligationApi = (body) => {
+    return sendRequest({
+        url: endpoints.obligations.create(),
+        method: "POST",
+        headers: {
+        Authorization: getToken(),
+        },
+        body,
+    });
+};
+
+// Delete obligation
+export const deleteObligationApi = (id) => {
+    return sendRequest({
+        url: endpoints.obligations.getById(id),
+        method: "DELETE",
+        headers: {
+        Authorization: getToken(),
+        },
+    });
+};
+
+// Export obligations CSV
+export const exportObligationCsvApi = (id = 0) => {
+    return sendRequest({
+        url: endpoints.obligations.exportCsv(),
+        method: "GET",
+        headers: {
+        Authorization: getToken(),
+        },
+        queryParams: {
+        id,
+        },
+        isFile: true,
+    });
+};
+
+// Export obligations JSON
+export const exportObligationJsonApi = (id = 0) => {
+    return sendRequest({
+        url: endpoints.obligations.exportJson(),
+        method: "GET",
+        headers: {
+        Authorization: getToken(),
+        },
+        queryParams: {
+        id,
+        },
+        isFile: true,
+    });
+};
+
+// Import obligations CSV
+export const importObligationCsvApi = (formData) => {
+  return sendRequest({
+    url: endpoints.obligations.importCsv(),
+    method: "POST",
+    isMultipart: true,
+    headers: {
+      Authorization: getToken(),
+    },
+    body: formData,
+  });
+};
+
+// Import obligations JSON
+export const importObligationJsonApi = (formData) => {
+  return sendRequest({
+    url: endpoints.obligations.importJson(),
+    method: "POST",
+    isMultipart: true,
+    headers: {
+      Authorization: getToken(),
+    },
+    body: formData,
+  });
+};

--- a/src/app/admin/obligation/ObligationTabsNav.jsx
+++ b/src/app/admin/obligation/ObligationTabsNav.jsx
@@ -1,0 +1,53 @@
+/*
+ SPDX-FileCopyrightText: 2026 Tiyasa Kundu (tiyasakundu20@gmail.com)
+
+SPDX-License-Identifier: GPL-2.0-only
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import routes from "@/constants/routes";
+
+const obligationTabs = [
+  { label: "Add Obligation", href: routes.admin.obligation.add},
+  { label: "Select Obligation", href: routes.admin.obligation.select},
+  { label: "Operations", href: routes.admin.obligation.operations },
+];
+
+export default function ObligationTabsNav() {
+  const pathname = usePathname();
+
+    const activeTab =
+    pathname.startsWith(routes.admin.obligation.operations)
+        ? routes.admin.obligation.operations
+        : pathname.startsWith(routes.admin.obligation.select)
+            ? routes.admin.obligation.select
+            : routes.admin.obligation.add;
+
+  return (
+    <Tabs value={activeTab}>
+      <TabsList>
+        {obligationTabs.map((tab) => (
+          <TabsTrigger key={tab.href} value={tab.href} asChild>
+            <Link href={tab.href}>{tab.label}</Link>
+          </TabsTrigger>
+        ))}
+      </TabsList>
+    </Tabs>
+  );
+}

--- a/src/app/admin/obligation/add/AddObligationClient.jsx
+++ b/src/app/admin/obligation/add/AddObligationClient.jsx
@@ -1,0 +1,454 @@
+/*
+ SPDX-FileCopyrightText: 2026 Tiyasa Kundu (tiyasakundu20@gmail.com)
+
+SPDX-License-Identifier: GPL-2.0-only
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+"use client";
+
+import { useEffect, useState } from "react";
+// UI Components
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import Chip from "@/components/ui/chip";
+import { SearchableMultiSelect } from "@/components/Widgets";
+import {
+  RadioGroup,
+  RadioGroupItem,
+} from "@/components/ui/radio-group";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { AlertBanner } from "@/components/ui/alert";
+//Api Services
+import {
+  getObligationsList
+} from "@/services/obligation";
+import { getAllLicense } from "@/services/licenses";
+
+const AddObligationClient = () => {
+    const [formData, setFormData] = useState({
+        active: true,
+        topic: "",
+        type: "obligation",
+        text: "",
+        attention: "green",
+        modifiedSource: false,
+        comment: "",
+        textUpdatable: true,
+    });
+
+    const [obligations, setObligations] = useState([]);
+    const [loading, setLoading] = useState(true);
+
+    const [selectedLicenses, setSelectedLicenses] = useState([]);
+    const [selectedCandidateLicenses, setSelectedCandidateLicenses] = useState([]);
+
+    const [licenses, setLicenses] = useState([]);
+    const [message, setMessage] = useState(null);
+    const [showMessage, setShowMessage] = useState(false);
+
+    useEffect(() => {
+        const fetchLicenses = async () => {
+            try {
+            const data = await getAllLicense({
+                page: 1,
+                limit: 1000,
+                kind: "all",
+            });
+            setLicenses(
+                data.map((license) => ({
+                label: license.shortName,
+                value: license.shortName,
+                id: license.id,
+                }))
+            );
+            } catch (err) {
+                setMessage({
+                    type: "error",
+                    text: err?.message || "Failed to load licenses.",
+                });
+                setShowMessage(true);
+                }
+        };
+
+        fetchLicenses();
+    }, []);
+
+    useEffect(() => {
+        const fetchObligations = async () => {
+            try {
+            const data = await getObligationsList();
+            setObligations(data || []);
+            } catch (err) {
+                setMessage({
+                    type: "error",
+                    text: err?.message || "Failed to load obligations.",
+                });
+                setShowMessage(true);
+                }finally {
+            setLoading(false);
+            }
+        };
+
+        fetchObligations();
+    }, []);
+
+    const handleSubmit = async () => {
+        const payload = {
+            ...formData,
+            licenses: selectedLicenses.map((license) => license.id),
+            candidateLicenses: selectedCandidateLicenses.map(
+                (license) => license.id
+            ),
+        };
+
+        try {
+            // await createObligation(payload);
+
+            setMessage({
+                type: "info",
+                text: "Add Obligation is not available yet. The backend API has not been implemented.",
+            });
+
+            // Later replace the above with:
+            /*
+            setMessage({
+                type: "success",
+                text: "Obligation added successfully.",
+            });
+            */
+
+            setShowMessage(true);
+        } catch (err) {
+            setMessage({
+                type: "error",
+                text: err?.message || "Failed to add obligation.",
+            });
+            setShowMessage(true);
+        }
+    };
+
+    const alertType =
+        message?.type === "danger" || message?.type === "error"
+            ? "Error"
+            : message?.type === "success"
+            ? "Success"
+            : "Info";
+    
+    const isFormValid =
+        formData.topic.trim() !== "" &&
+        formData.text.trim() !== "" &&
+        (
+            selectedLicenses.length > 0 ||
+            selectedCandidateLicenses.length > 0
+        );
+
+    return (
+        <div>
+            {showMessage && message && (
+            <div className="mb-4">
+                <AlertBanner
+                type={alertType}
+                description={message.text}
+                showClose
+                onClose={() => setShowMessage(false)}
+                />
+            </div>
+            )}
+
+            <h1 className="text-2xl font-semibold text-gray-900 mb-8">
+            Add Obligation
+            </h1>
+
+        <div className="space-y-8">
+
+        {/* Active */}
+        <div className="space-y-2">
+            <Label>Active</Label>
+
+            <Select
+                value={String(formData.active ? "true" : "false")}
+                onValueChange={(value) =>
+                    setFormData((prev) => ({
+                        ...prev,
+                        active: value === "true",
+                    }))
+                }
+            >
+                <SelectTrigger className="w-[320px]">
+                    <SelectValue placeholder="Yes" />
+                </SelectTrigger>
+
+            <SelectContent>
+                <SelectItem value="true">Yes</SelectItem>
+                <SelectItem value="false">No</SelectItem>
+            </SelectContent>
+            </Select>
+        </div>
+
+        {/* Topic */}
+        <div className="space-y-2">
+            <Label>Obligation Topic</Label>
+
+            <Input
+                value={formData.topic}
+                onChange={(e) =>
+                    setFormData((prev) => ({
+                        ...prev,
+                        topic: e.target.value,
+                    }))
+                }
+                placeholder="Enter obligation topic"
+                className="w-[800px]"
+            />
+        </div>
+
+        {/* Type */}
+        <div className="space-y-3">
+            <p className="text-base">
+                Type of obligation
+            </p>
+
+            <RadioGroup
+                value={formData.type}
+                onValueChange={(value) =>
+                    setFormData((prev) => ({
+                        ...prev,
+                        type: value,
+                    }))
+                }
+                className="flex flex-row flex-wrap items-center gap-6"
+            >
+            {[
+                ["obligation", "Obligation"],
+                ["restriction", "Restriction"],
+                ["risk", "Risk"],
+                ["right", "Right"],
+            ].map(([value, label]) => (
+                <div
+                    key={value}
+                    className="flex shrink-0 items-center gap-2"
+                >
+                <RadioGroupItem
+                    value={value}
+                    id={value}
+                />
+                <Label htmlFor={value}>{label}</Label>
+                </div>
+            ))}
+            </RadioGroup>
+        </div>
+
+        {/* Obligation text */}
+        <div className="space-y-2">
+            <Label>Obligation Text</Label>
+
+            <Textarea
+                value={formData.text}
+                onChange={(e) =>
+                    setFormData((prev) => ({
+                        ...prev,
+                        text: e.target.value,
+                    }))
+                }
+                className="min-w-[800px] resize"
+                placeholder="Enter obligation text"
+            />
+        </div>
+
+        {/* Attention */}
+        <div className="space-y-3">
+            <p className="text-base">
+                Optional: level of attention this obligation
+                should raise in the clearing process
+            </p>
+
+            <RadioGroup
+                value={formData.attention}
+                onValueChange={(value) =>
+                    setFormData((prev) => ({
+                        ...prev,
+                        attention: value,
+                    }))
+                }
+                className="flex flex-row flex-wrap items-center gap-6"
+            >
+            {[
+                {
+                    value: "green",
+                    label: "Green",
+                    className:
+                    "bg-success-500 text-white border-success-500",
+                },
+                {
+                    value: "white",
+                    label: "White",
+                    className:
+                    "bg-white text-neutral-900 border-neutral-400",
+                },
+                {
+                    value: "yellow",
+                    label: "Yellow",
+                    className:
+                    "bg-yellow-100 text-neutral-900 border-yellow-100",
+                },
+                {
+                    value: "red",
+                    label: "Red",
+                    className:
+                    "bg-alert-500 text-white border-alert-500",
+                },
+                ].map(({ value, label, className }) => (
+                <div
+                key={value}
+                className="flex shrink-0 items-center gap-2"
+                >
+                <RadioGroupItem
+                    value={value}
+                    id={value}
+                />
+
+                <Label htmlFor={value} className="cursor-pointer">
+                    <Chip
+                        label={label}
+                        removable={false}
+                        interactive={false}
+                        variant="custom"
+                        className={`h-7 px-2 py-1 rounded border justify-center ${className}`}
+                    />
+                </Label>
+                </div>
+            ))}
+            </RadioGroup>
+        </div>
+
+        {/* Modified source */}
+        <div className="space-y-2">
+            <Label>
+                Optional: does this obligation apply on
+                modified source code?
+            </Label>
+
+            <Select
+                value={String(formData.modifiedSource)}
+                onValueChange={(value) =>
+                    setFormData((prev) => ({
+                    ...prev,
+                    modifiedSource: value === "true",
+                    }))
+                }
+                >
+                <SelectTrigger className="w-[320px]">
+                    <SelectValue />
+                </SelectTrigger>
+
+                <SelectContent>
+                    <SelectItem value="true">Yes</SelectItem>
+                    <SelectItem value="false">No</SelectItem>
+                </SelectContent>
+                </Select>
+        </div>
+
+        {/* Associated Licenses */}
+        <div className="space-y-2">
+            <Label>
+                Associated Licenses (conclusions)
+            </Label>
+
+            <SearchableMultiSelect
+                options={licenses}
+                value={selectedLicenses}
+                onChange={setSelectedLicenses}
+                placeholder="Search and select licenses associated with this obligation"
+            />
+        </div>
+
+        {/* Candidate licenses */}
+        <div className="space-y-2">
+        <Label>
+            Optional: Associated Candidate Licenses
+        </Label>
+
+        <SearchableMultiSelect
+            options={licenses}
+            value={selectedCandidateLicenses}
+            onChange={setSelectedCandidateLicenses}
+            placeholder="Search and select candidate licenses associated with this obligation"
+        />
+        </div>
+
+        {/* Comment */}
+        <div className="space-y-2">
+            <Label>Optional: comment</Label>
+
+            <Textarea
+                value={formData.comment}
+                onChange={(e) =>
+                    setFormData((prev) => ({
+                        ...prev,
+                        comment: e.target.value,
+                    }))
+                }
+                className="min-w-[800px] resize"
+                placeholder="Enter comment"
+            />
+        </div>
+
+        {/* Updatable */}
+        <div className="space-y-2">
+            <Label>Text Updatable</Label>
+
+            <Select
+                value={String(formData.textUpdatable ? "true" : "false")}
+                onValueChange={(value) =>
+                    setFormData((prev) => ({
+                        ...prev,
+                        textUpdatable: value === "true",
+                    }))
+                }
+            >
+            <SelectTrigger className="w-[320px]">
+                <SelectValue placeholder="Yes" />
+            </SelectTrigger>
+
+            <SelectContent>
+                <SelectItem value="true">Yes</SelectItem>
+                <SelectItem value="false">No</SelectItem>
+            </SelectContent>
+            </Select>
+        </div>
+
+        <div className="pb-6">
+            <Button
+                onClick={handleSubmit}
+                disabled={!isFormValid}
+            >
+                Add Obligation
+            </Button>
+        </div>
+
+        </div>
+    </div>
+    );
+};
+
+export default AddObligationClient;

--- a/src/app/admin/obligation/add/page.jsx
+++ b/src/app/admin/obligation/add/page.jsx
@@ -1,0 +1,27 @@
+/*
+ SPDX-FileCopyrightText: 2025 Tiyasa Kundu (tiyasakundu20@gmail.com)
+
+SPDX-License-Identifier: GPL-2.0-only
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+import AddObligationClient from "./AddObligationClient";
+
+export const metadata = {
+    title: "Add OBligation | FOSSology",
+};
+
+export default function AddObligationPage() {
+    return <AddObligationClient />;
+}

--- a/src/app/admin/obligation/layout.jsx
+++ b/src/app/admin/obligation/layout.jsx
@@ -1,8 +1,7 @@
 /*
- Copyright (C) 2021 Shruti Agarwal (mail2shruti.ag@gmail.com)
  SPDX-FileCopyrightText: 2026 Tiyasa Kundu (tiyasakundu20@gmail.com)
 
- SPDX-License-Identifier: GPL-2.0
+SPDX-License-Identifier: GPL-2.0-only
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
@@ -17,20 +16,14 @@
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-import Alert from "./Alert";
-import Button from "./Button";
-import Image from "./Image";
-import InputContainer from "./Input";
-import Tooltip from "./Tooltip";
-import SearchableMultiSelect from "./SearchableMultiSelect";
+import ObligationTabsNav from "./ObligationTabsNav";
 
-const Spinner = ({ size = "default" }) => (
-  <span
-    className={`inline-block rounded-full border-2 border-current border-t-transparent animate-spin ${
-      size === "sm" ? "w-4 h-4" : "w-6 h-6"
-    }`}
-    aria-hidden="true"
-  />
-);
-
-export { Alert, Button, Image, InputContainer, Tooltip, SearchableMultiSelect, Spinner };
+export default function ObligationLayout({ children }) {
+  return (
+    <div className="mx-40 px-4">
+      <h1 className="text-2xl font-semibold text-gray-900 mt-6 mb-4">Obligations and Risks Administration</h1>
+      <ObligationTabsNav />
+      <div className="mt-6">{children}</div>
+    </div>
+  );
+}

--- a/src/app/admin/obligation/operations/OperationsClient.jsx
+++ b/src/app/admin/obligation/operations/OperationsClient.jsx
@@ -1,0 +1,183 @@
+/*
+ SPDX-FileCopyrightText: 2026 Tiyasa Kundu (tiyasakundu20@gmail.com)
+
+SPDX-License-Identifier: GPL-2.0-only
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+// UI Component
+import { Button } from "@/components/ui/button";
+import { AlertBanner } from "@/components/ui/alert";
+// Route
+import routes from "@/constants/routes";
+// API Services
+import {
+    exportObligationCsv,
+    exportObligationJson,
+} from "@/services/obligation";
+
+const OperationsClient = () => {
+    const router = useRouter();
+
+    const [message, setMessage] = useState(null);
+    const [showMessage, setShowMessage] = useState(false);
+    const [exporting, setExporting] = useState(null);
+
+    const downloadFile = ({ blob, filename }) => {
+        const url = URL.createObjectURL(blob);
+
+        const link = document.createElement("a");
+        link.href = url;
+        link.download = filename;
+
+        document.body.appendChild(link);
+        link.click();
+
+        link.remove();
+        URL.revokeObjectURL(url);
+    };
+
+    const createFilename = (extension) => {
+        const now = new Date();
+
+        const year = now.getFullYear();
+        const month = now.toLocaleString("en-US", { month: "short" });
+        const day = now.getDate();
+
+        const random = Math.floor(10000 + Math.random() * 90000);
+
+        return `fossology-obligations-export-${year}${month}${day}-${random}.${extension}`;
+    };
+
+    const handleJsonExport = async () => {
+    try {
+        setExporting("json");
+
+        const file = await exportObligationJson();
+
+        downloadFile({
+        blob: file.blob,
+        filename:
+            file.filename || createFilename("json"),
+        });
+
+        setMessage({
+        type: "success",
+        text: "JSON exported successfully.",
+        });
+    } catch (err) {
+        setMessage({
+        type: "error",
+        text: err?.message || "Failed to export JSON.",
+        });
+    } finally {
+        setExporting(null);
+        setShowMessage(true);
+    }
+    };
+
+    const handleCsvExport = async () => {
+    try {
+        setExporting("csv");
+
+        const file = await exportObligationCsv();
+
+        downloadFile({
+        blob: file.blob,
+        filename:
+            file.filename || createFilename("csv"),
+        });
+
+        setMessage({
+        type: "success",
+        text: "CSV exported successfully.",
+        });
+    } catch (err) {
+        setMessage({
+        type: "error",
+        text: err?.message || "Failed to export CSV.",
+        });
+    } finally {
+        setExporting(null);
+        setShowMessage(true);
+    }
+    };
+
+    const handleImport = () => {
+        router.push(routes.admin.obligation.obligationImport);
+    };
+
+    const alertType =
+    message?.type === "danger" || message?.type === "error"
+        ? "Error"
+        : message?.type === "success"
+        ? "Success"
+        : "Info";
+
+    return (
+        <div>
+            {showMessage && message && (
+                <div className="mb-4">
+                    <AlertBanner
+                    type={alertType}
+                    description={message.text}
+                    showClose
+                    onClose={() => setShowMessage(false)}
+                    />
+                </div>
+            )}
+            <h1 className="mb-6 text-2xl font-semibold text-gray-900">
+                Operations
+            </h1>
+
+            <div className="flex gap-6">
+            <Button
+            type="button"
+            variant="default"
+            onClick={handleJsonExport}
+            disabled={exporting === "json"}
+            >
+            {exporting === "json"
+                ? "Exporting..."
+                : "JSON Export"}
+            </Button>
+
+            <Button
+            type="button"
+            variant="default"
+            onClick={handleCsvExport}
+            disabled={exporting === "csv"}
+            >
+            {exporting === "csv"
+                ? "Exporting..."
+                : "CSV Export"}
+            </Button>
+
+                <Button
+                type="button"
+                variant="default"
+                onClick={handleImport}
+                >
+                Obligation Import
+                </Button>
+            </div>
+        </div>
+    );
+};
+
+export default OperationsClient;

--- a/src/app/admin/obligation/operations/obligationImport/ObligationImportClient.jsx
+++ b/src/app/admin/obligation/operations/obligationImport/ObligationImportClient.jsx
@@ -1,0 +1,290 @@
+/*
+ SPDX-FileCopyrightText: 2026 Tiyasa Kundu (tiyasakundu20@gmail.com)
+
+SPDX-License-Identifier: GPL-2.0-only
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+"use client";
+
+import { useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import routes from "@/constants/routes";
+
+import { Button } from "@/components/ui/button";
+import { AlertBanner } from "@/components/ui/alert";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+import {
+importObligationCsv,
+importObligationJson,
+} from "@/services/obligation";
+
+export default function ObligationImportClient() {
+const router = useRouter();
+
+const [files, setFiles] = useState([]);
+const [delimiter, setDelimiter] = useState("");
+const [enclosure, setEnclosure] = useState("");
+const [message, setMessage] = useState(null);
+const [showMessage, setShowMessage] = useState(false);
+const [importResults, setImportResults] = useState([]);
+const [uploading, setUploading] = useState(false);
+
+const fileInputRef = useRef(null);
+
+const handleSubmit = async (e) => {
+  e.preventDefault();
+
+  if (files.length === 0) return;
+
+  try {
+    setUploading(true);
+
+    const uploadableFiles = files.filter((file) => {
+      const ext = file.name.split(".").pop()?.toLowerCase();
+      return ext === "csv" || ext === "json";
+    });
+
+    if (uploadableFiles.length === 0) {
+      setMessage({
+        type: "error",
+        text: "Only CSV and JSON files are supported.",
+      });
+      setShowMessage(true);
+      return;
+    }
+
+    const results = [];
+
+    for (const file of uploadableFiles) {
+      const ext = file.name.split(".").pop()?.toLowerCase();
+      const formData = new FormData();
+
+      let response;
+
+      if (ext === "csv") {
+        formData.append("fileInput", file);
+        formData.append("delimiter", delimiter || ",");
+        formData.append("enclosure", enclosure || '"');
+
+        response = await importObligationCsv(formData);
+      } else {
+        formData.append("fileInput", file);
+
+        response = await importObligationJson(formData);
+      }
+
+      results.push({
+        fileName: file.name,
+        message: response?.message || "Imported successfully",
+      });
+    }
+
+    setImportResults(results);
+
+    setMessage({
+      type: "success",
+      text: `${uploadableFiles.length} file(s) imported successfully.`,
+    });
+
+    setShowMessage(true);
+  } catch (error) {
+    console.error(error);
+
+    setImportResults([]);
+
+    setMessage({
+      type: "error",
+      text:
+        error?.message ||
+        error?.body?.message ||
+        "Obligation import failed",
+    });
+
+    setShowMessage(true);
+  } finally {
+    setUploading(false);
+  }
+};
+
+const handleBack = () => {
+    router.push(routes.admin.obligation.operations);
+};
+
+return (
+    <div>
+        {showMessage && message && (
+        <div className="mb-4">
+            <AlertBanner
+            type={
+                message.type === "error"
+                ? "Error"
+                : message.type === "success"
+                ? "Success"
+                : "Info"
+            }
+            description={message.text}
+            showClose
+            onClose={() => setShowMessage(false)}
+            />
+        </div>
+        )}
+    <h1 className="text-2xl font-semibold text-gray-900 mb-6">
+        Operations
+    </h1>
+
+    <h2 className="text-lg font-semibold text-gray-900 mb-4">
+        Obligation Import
+    </h2>
+
+    <p className="mb-6 max-w-5xl text-base text-gray-900">
+        This option permits uploading a CSV or JSON file from your computer to FOSSology.
+        <br />
+        Your FOSSology server has imposed a maximum upload file size of 700Mbytes
+    </p>
+
+    <form onSubmit={handleSubmit}>
+        <div className="mb-6">
+            <Label className="block mb-3">
+                Select the CSV-file or JSON-file to upload:
+            </Label>
+
+            <div className="flex items-end gap-3">
+            <input
+            ref={fileInputRef}
+            type="file"
+            accept=".csv,.json"
+            multiple
+            disabled={uploading}
+            className="hidden"
+            onChange={(e) =>
+                setFiles(Array.from(e.target.files || []))
+            }
+            />
+
+            <Button
+            type="button"
+            variant="outline"
+            disabled={uploading}
+            className="font-medium text-primary rounded border-primary hover:bg-accent hover:text-accent-foreground"
+            onClick={() => fileInputRef.current?.click()}
+            >
+            Choose Files
+            </Button>
+
+            <span
+            className={`self-end text-sm ${
+                files.length > 0
+                ? "text-info-500"
+                : "text-error-600"
+            }`}
+            >
+            {files.length > 0 ? (
+                <div className="flex flex-wrap gap-3">
+                {files.map((file) => (
+                    <span key={file.name}>
+                    {file.name}
+                    </span>
+                ))}
+                </div>
+            ) : (
+                "No file chosen"
+            )}
+            </span>
+        </div>
+
+        <div className="mt-6 space-y-4">
+            <div className="flex items-center gap-4">
+            <Label className="min-w-[100px]">
+                Delimiter:
+            </Label>
+
+            <Input
+                type="text"
+                name="delimiter"
+                placeholder=","
+                value={delimiter}
+                onChange={(e) =>
+                setDelimiter(e.target.value)
+                }
+                className="w-[160px]"
+            />
+            </div>
+
+            <div className="flex items-center gap-4">
+            <Label className="min-w-[100px]">
+                Enclosure:
+            </Label>
+
+            <Input
+                type="text"
+                name="enclosure"
+                placeholder={'"'}
+                value={enclosure}
+                onChange={(e) =>
+                setEnclosure(e.target.value)
+                }
+                className="w-[160px]"
+            />
+            </div>
+        </div>
+        </div>
+
+        <div className="flex gap-6">
+        <Button
+            type="button"
+            variant="outline"
+            onClick={handleBack}
+        >
+            Back
+        </Button>
+
+        <Button
+        type="submit"
+        disabled={files.length === 0 || uploading}
+        >
+        {uploading ? "Uploading..." : "Upload"}
+        </Button>
+        </div>
+
+        {importResults.length > 0 && (
+            <div className="mt-8">
+                <div className="mb-4">
+                <h3 className="font-normal text-foreground mb-4">
+                    Import Results
+                </h3>
+
+                <div className="space-y-6">
+                    {importResults.map((result) => (
+                    <div key={result.fileName}>
+                        <p className="font-medium text-foreground mb-2">
+                        {result.fileName}
+                        </p>
+
+                        <div className="whitespace-pre-line text-sm text-foreground">
+                        {result.message}
+                        </div>
+                    </div>
+                    ))}
+                </div>
+                </div>
+            </div>
+            )}
+    </form>
+    </div>
+);
+}

--- a/src/app/admin/obligation/operations/obligationImport/page.jsx
+++ b/src/app/admin/obligation/operations/obligationImport/page.jsx
@@ -1,8 +1,7 @@
 /*
- Copyright (C) 2021 Shruti Agarwal (mail2shruti.ag@gmail.com)
  SPDX-FileCopyrightText: 2026 Tiyasa Kundu (tiyasakundu20@gmail.com)
 
- SPDX-License-Identifier: GPL-2.0
+SPDX-License-Identifier: GPL-2.0-only
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
@@ -17,20 +16,8 @@
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-import Alert from "./Alert";
-import Button from "./Button";
-import Image from "./Image";
-import InputContainer from "./Input";
-import Tooltip from "./Tooltip";
-import SearchableMultiSelect from "./SearchableMultiSelect";
+import ObligationImportClient from "./ObligationImportClient";
 
-const Spinner = ({ size = "default" }) => (
-  <span
-    className={`inline-block rounded-full border-2 border-current border-t-transparent animate-spin ${
-      size === "sm" ? "w-4 h-4" : "w-6 h-6"
-    }`}
-    aria-hidden="true"
-  />
-);
-
-export { Alert, Button, Image, InputContainer, Tooltip, SearchableMultiSelect, Spinner };
+export default function ObligationImportPage() {
+  return <ObligationImportClient />;
+}

--- a/src/app/admin/obligation/operations/page.jsx
+++ b/src/app/admin/obligation/operations/page.jsx
@@ -1,8 +1,7 @@
 /*
- Copyright (C) 2021 Shruti Agarwal (mail2shruti.ag@gmail.com)
  SPDX-FileCopyrightText: 2026 Tiyasa Kundu (tiyasakundu20@gmail.com)
 
- SPDX-License-Identifier: GPL-2.0
+SPDX-License-Identifier: GPL-2.0-only
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
@@ -17,20 +16,12 @@
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-import Alert from "./Alert";
-import Button from "./Button";
-import Image from "./Image";
-import InputContainer from "./Input";
-import Tooltip from "./Tooltip";
-import SearchableMultiSelect from "./SearchableMultiSelect";
+import OperationsClient from "./OperationsClient";
 
-const Spinner = ({ size = "default" }) => (
-  <span
-    className={`inline-block rounded-full border-2 border-current border-t-transparent animate-spin ${
-      size === "sm" ? "w-4 h-4" : "w-6 h-6"
-    }`}
-    aria-hidden="true"
-  />
-);
+export const metadata = {
+    title: "Obligation Operations | FOSSology",
+};
 
-export { Alert, Button, Image, InputContainer, Tooltip, SearchableMultiSelect, Spinner };
+export default function SelectObligationPage() {
+    return <OperationsClient />;
+}

--- a/src/app/admin/obligation/page.jsx
+++ b/src/app/admin/obligation/page.jsx
@@ -1,8 +1,7 @@
 /*
- Copyright (C) 2021 Shruti Agarwal (mail2shruti.ag@gmail.com)
  SPDX-FileCopyrightText: 2026 Tiyasa Kundu (tiyasakundu20@gmail.com)
 
- SPDX-License-Identifier: GPL-2.0
+SPDX-License-Identifier: GPL-2.0-only
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
@@ -17,20 +16,9 @@
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-import Alert from "./Alert";
-import Button from "./Button";
-import Image from "./Image";
-import InputContainer from "./Input";
-import Tooltip from "./Tooltip";
-import SearchableMultiSelect from "./SearchableMultiSelect";
+import { redirect } from "next/navigation";
+import routes from "@/constants/routes";
 
-const Spinner = ({ size = "default" }) => (
-  <span
-    className={`inline-block rounded-full border-2 border-current border-t-transparent animate-spin ${
-      size === "sm" ? "w-4 h-4" : "w-6 h-6"
-    }`}
-    aria-hidden="true"
-  />
-);
-
-export { Alert, Button, Image, InputContainer, Tooltip, SearchableMultiSelect, Spinner };
+export default function ObligationIndexPage() {
+  redirect(routes.admin.obligation.add);
+}

--- a/src/app/admin/obligation/select/SelectObligationClient.jsx
+++ b/src/app/admin/obligation/select/SelectObligationClient.jsx
@@ -1,0 +1,211 @@
+/*
+ SPDX-FileCopyrightText: 2026 Tiyasa Kundu (tiyasakundu20@gmail.com)
+
+SPDX-License-Identifier: GPL-2.0-only
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+"use client";
+
+import { useEffect, useState } from "react";
+// UI Components
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { AlertBanner } from "@/components/ui/alert";
+// API services
+import { getObligationsList, getAllObligations } from "@/services/obligation";
+
+const SelectObligationClient = () => {
+    const [topic, setTopic] = useState("");
+    const [topics, setTopics] = useState([]);
+    const [results, setResults] = useState([]);
+    const [loading, setLoading] = useState(false);
+    const [searched, setSearched] = useState(false);
+    const [message, setMessage] = useState(null);
+    const [showMessage, setShowMessage] = useState(false);
+
+    const handleFind = async () => {
+    setLoading(true);
+
+    try {
+        const data = await getAllObligations();
+
+        let filteredResults;
+
+        if (topic === "all") {
+        filteredResults = data;
+        } else {
+        filteredResults = data.filter(
+            (obligation) => obligation.topic === topic
+        );
+        }
+
+        setResults(filteredResults);
+        setSearched(true);
+
+        if (filteredResults.length === 0) {
+        setMessage({
+            type: "info",
+            text: "No obligations found.",
+        });
+        } else {
+        setMessage({
+            type: "success",
+            text:
+            topic === "all"
+                ? "Obligations loaded successfully."
+                : "Search completed successfully.",
+        });
+        }
+
+        setShowMessage(true);
+    } catch (err) {
+        setMessage({
+        type: "error",
+        text: err?.message || "Failed to fetch obligations.",
+        });
+        setShowMessage(true);
+    } finally {
+        setLoading(false);
+    }
+    };
+
+    useEffect(() => {
+        const fetchTopics = async () => {
+            try {
+            const data = await getObligationsList();
+
+            setTopics(data || []);
+            } catch (err) {
+                setMessage({
+                    type: "error",
+                    text: err?.message || "Failed to load obligation topics.",
+                });
+                setShowMessage(true);
+                }
+        };
+
+        fetchTopics();
+    }, []);
+
+    const alertType =
+        message?.type === "danger" || message?.type === "error"
+            ? "Error"
+            : message?.type === "success"
+            ? "Success"
+            : "Info";
+
+    return (
+        <div>
+            {showMessage && message && (
+            <div className="mb-4">
+                <AlertBanner
+                    type={alertType}
+                    description={message.text}
+                    showClose
+                    onClose={() => setShowMessage(false)}
+                />
+            </div>
+            )}
+
+            <h1 className="mb-8 text-2xl font-semibold text-gray-900">
+                Select Obligation
+            </h1>
+
+            <div className="space-y-8">
+                <p>
+                From which topic do you wish to view the obligations and risks:
+                </p>
+
+                <div className="space-y-2">
+                <Label>From topic:</Label>
+
+                <Select value={topic} onValueChange={setTopic}>
+                    <SelectTrigger className="w-[320px]">
+                        <SelectValue placeholder="All" />
+                    </SelectTrigger>
+
+                    <SelectContent>
+                        <SelectItem value="all">All</SelectItem>
+
+                        {topics.map((item) => (
+                        <SelectItem
+                            key={item.id}
+                            value={item.obligationTopic}
+                        >
+                            {item.obligationTopic}
+                        </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+                </div>
+
+                <Button
+                onClick={handleFind}
+                disabled={!topic || loading}
+                >
+                {loading ? "Finding..." : "Find"}
+                </Button>
+
+                {searched && (
+                <div className="mt-8 space-y-4">
+                    {results.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">
+                        No obligations found.
+                    </p>
+                    ) : (
+                    results.map((item) => (
+                        <div
+                        key={item.id}
+                        className="rounded-md border p-4 space-y-2"
+                        >
+                        <p>
+                            <strong>Type:</strong> {item.type}
+                        </p>
+
+                        <p>
+                            <strong>Topic:</strong> {item.topic}
+                        </p>
+
+                        <p>
+                            <strong>Text:</strong> {item.text}
+                        </p>
+
+                        <p>
+                            <strong>Classification:</strong>{" "}
+                            {item.classification}
+                        </p>
+
+                        <p>
+                            <strong>Comment:</strong>{" "}
+                            {item.comment || "-"}
+                        </p>
+                        </div>
+                    ))
+                    )}
+                </div>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default SelectObligationClient;

--- a/src/app/admin/obligation/select/page.jsx
+++ b/src/app/admin/obligation/select/page.jsx
@@ -1,8 +1,7 @@
 /*
- Copyright (C) 2021 Shruti Agarwal (mail2shruti.ag@gmail.com)
  SPDX-FileCopyrightText: 2026 Tiyasa Kundu (tiyasakundu20@gmail.com)
 
- SPDX-License-Identifier: GPL-2.0
+SPDX-License-Identifier: GPL-2.0-only
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
@@ -17,20 +16,12 @@
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-import Alert from "./Alert";
-import Button from "./Button";
-import Image from "./Image";
-import InputContainer from "./Input";
-import Tooltip from "./Tooltip";
-import SearchableMultiSelect from "./SearchableMultiSelect";
+import SelectObligationClient from "./SelectObligationClient";
 
-const Spinner = ({ size = "default" }) => (
-  <span
-    className={`inline-block rounded-full border-2 border-current border-t-transparent animate-spin ${
-      size === "sm" ? "w-4 h-4" : "w-6 h-6"
-    }`}
-    aria-hidden="true"
-  />
-);
+export const metadata = {
+    title: "Select Obligation | FOSSology",
+};
 
-export { Alert, Button, Image, InputContainer, Tooltip, SearchableMultiSelect, Spinner };
+export default function SelectObligationPage() {
+    return <SelectObligationClient />;
+}

--- a/src/components/Widgets/SearchableMultiSelect/index.jsx
+++ b/src/components/Widgets/SearchableMultiSelect/index.jsx
@@ -30,7 +30,7 @@ const SearchableMultiSelect = ({
   options = [],
   value = [],
   onChange,
-  placeholder = "Search...",
+  placeholder = "Search",
   className,
 }) => {
   const [open, setOpen] = useState(false);
@@ -44,20 +44,27 @@ const SearchableMultiSelect = ({
     );
   }, [options, search]);
 
-  const toggleOption = (option) => {
-    const exists = value.some((item) => item.value === option.value);
+const toggleOption = (option) => {
+  const exists = value.some(
+    (item) => item.id === option.id
+  );
 
-    if (exists) {
-      onChange(value.filter((item) => item.value !== option.value));
-    } else {
-      onChange([...value, option]);
-    }
-      setSearch("");
-  };
+  if (exists) {
+    onChange(
+      value.filter((item) => item.id !== option.id)
+    );
+  } else {
+    onChange([...value, option]);
+  }
 
-  const removeOption = (option) => {
-    onChange(value.filter((item) => item.value !== option.value));
-  };
+  setSearch("");
+};
+
+const removeOption = (option) => {
+  onChange(
+    value.filter((item) => item.id !== option.id)
+  );
+};
 
   useEffect(() => {
     function handleClickOutside(event) {
@@ -85,7 +92,7 @@ const SearchableMultiSelect = ({
         <div className="flex flex-wrap items-center gap-2 flex-1">
             {value.map((item) => (
             <Chip
-                key={item.value}
+                key={item.id}
                 label={item.label}
                 onRemove={() => removeOption(item)}
             />
@@ -137,41 +144,41 @@ const SearchableMultiSelect = ({
         </InputGroup>
 
     {open && (
-        <div className="absolute left-0 top-full z-50 mt-1 w-full overflow-hidden rounded-b border-x border-b border-neutral-300 border-t-0 bg-white shadow-[0px_4px_6px_0px_#00000017]">
-        <ScrollArea className="max-h-64">
-            {filteredOptions.length === 0 ? (
-            <div className="px-4 py-3 text-sm text-muted-foreground">
-                No results found.
-            </div>
-            ) : (
-            filteredOptions.map((option) => {
-                const selected = value.some(
-                (item) => item.value === option.value
-                );
-
-                return (
-                <button
-                    key={option.value}
-                    type="button"
-                    onMouseDown={(e) => e.preventDefault()}
-                    onClick={() => toggleOption(option)}
-                    className={cn(
-                    "relative flex h-[36px] w-full items-center justify-between px-3 text-[14px] leading-[20px]",
-                    "hover:bg-neutral-100",
-                    selected && "bg-accent"
-                    )}
-                >
-                    {option.label}
-
-                    {selected && (
-                    <Check className="h-4 w-4 text-primary" />
-                    )}
-                </button>
-                );
-            })
-            )}
-        </ScrollArea>
+    <div className="absolute left-0 top-full z-50 mt-1 w-full overflow-hidden rounded-b border-x border-b border-neutral-300 border-t-0 bg-white shadow-[0px_4px_6px_0px_#00000017]">
+      <ScrollArea className="max-h-64 w-full">
+        {filteredOptions.length === 0 ? (
+        <div className="px-4 py-3 text-sm text-muted-foreground">
+            No results found.
         </div>
+        ) : (
+        filteredOptions.map((option) => {
+            const selected = value.some(
+            (item) => item.id === option.id
+            );
+
+            return (
+            <button
+                key={option.id}
+                type="button"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => toggleOption(option)}
+                className={cn(
+                "relative flex h-[36px] w-full items-center justify-between px-3 text-[14px] leading-[20px]",
+                "hover:bg-neutral-100",
+                selected && "bg-accent"
+                )}
+            >
+                {option.label}
+
+                {selected && (
+                <Check className="h-4 w-4 text-primary" />
+                )}
+            </button>
+            );
+        })
+        )}
+    </ScrollArea>
+    </div>
     )}
     </div>
     );

--- a/src/components/Widgets/SearchableMultiSelect/index.jsx
+++ b/src/components/Widgets/SearchableMultiSelect/index.jsx
@@ -1,0 +1,180 @@
+/*
+ SPDX-FileCopyrightText: 2026 Tiyasa Kundu (tiyasakundu20@gmail.com)
+
+SPDX-License-Identifier: GPL-2.0-only
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+"use client";
+
+import { useMemo, useRef, useState, useEffect } from "react";
+import { Check } from "lucide-react";
+
+import Chip from "@/components/ui/chip";
+import { InputGroup } from "@/components/ui/input-group";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { cn } from "@/lib/utils";
+
+const SearchableMultiSelect = ({
+  options = [],
+  value = [],
+  onChange,
+  placeholder = "Search...",
+  className,
+}) => {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+
+  const inputRef = useRef(null);
+
+  const filteredOptions = useMemo(() => {
+    return options.filter((option) =>
+      option.label.toLowerCase().includes(search.toLowerCase())
+    );
+  }, [options, search]);
+
+  const toggleOption = (option) => {
+    const exists = value.some((item) => item.value === option.value);
+
+    if (exists) {
+      onChange(value.filter((item) => item.value !== option.value));
+    } else {
+      onChange([...value, option]);
+    }
+      setSearch("");
+  };
+
+  const removeOption = (option) => {
+    onChange(value.filter((item) => item.value !== option.value));
+  };
+
+  useEffect(() => {
+    function handleClickOutside(event) {
+        if (
+        inputRef.current &&
+        !inputRef.current.closest(".search-input-container")?.contains(event.target)
+        ) {
+        setOpen(false);
+        }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+
+    return () => {
+        document.removeEventListener("mousedown", handleClickOutside);
+    };
+    }, []);
+
+  return (
+    <div className="search-input-container relative w-[800px]">
+        <InputGroup
+        onClick={() => inputRef.current?.focus()}
+        className="min-h-9 h-auto"
+        >
+        <div className="flex flex-wrap items-center gap-2 flex-1">
+            {value.map((item) => (
+            <Chip
+                key={item.value}
+                label={item.label}
+                onRemove={() => removeOption(item)}
+            />
+            ))}
+
+            <input
+            ref={inputRef}
+            data-slot="input-group-control"
+            value={search}
+            onFocus={() => setOpen(true)}
+            onChange={(e) => {
+                setSearch(e.target.value);
+                setOpen(true);
+            }}
+            onKeyDown={(e) => {
+            if (e.key === "Escape") {
+                setOpen(false);
+                return;
+            }
+
+            if (e.key === "Enter") {
+                e.preventDefault();
+
+                if (filteredOptions.length > 0) {
+                toggleOption(filteredOptions[0]);
+                }
+                return;
+            }
+
+            if (e.key === "Backspace" && search === "" && value.length > 0) {
+                e.preventDefault();
+
+                const lastSelected = value[value.length - 1];
+                removeOption(lastSelected);
+            }
+            }}
+            placeholder={value.length === 0 ? placeholder : ""}
+            className="
+                flex-1
+                min-w-[120px]
+                bg-transparent
+                border-0
+                outline-none
+                text-sm
+                placeholder:text-neutral-800
+            "
+            />
+        </div>
+        </InputGroup>
+
+    {open && (
+        <div className="absolute left-0 top-full z-50 mt-1 w-full overflow-hidden rounded-b border-x border-b border-neutral-300 border-t-0 bg-white shadow-[0px_4px_6px_0px_#00000017]">
+        <ScrollArea className="max-h-64">
+            {filteredOptions.length === 0 ? (
+            <div className="px-4 py-3 text-sm text-muted-foreground">
+                No results found.
+            </div>
+            ) : (
+            filteredOptions.map((option) => {
+                const selected = value.some(
+                (item) => item.value === option.value
+                );
+
+                return (
+                <button
+                    key={option.value}
+                    type="button"
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={() => toggleOption(option)}
+                    className={cn(
+                    "relative flex h-[36px] w-full items-center justify-between px-3 text-[14px] leading-[20px]",
+                    "hover:bg-neutral-100",
+                    selected && "bg-accent"
+                    )}
+                >
+                    {option.label}
+
+                    {selected && (
+                    <Check className="h-4 w-4 text-primary" />
+                    )}
+                </button>
+                );
+            })
+            )}
+        </ScrollArea>
+        </div>
+    )}
+    </div>
+    );
+};
+
+export default SearchableMultiSelect;

--- a/src/components/ui/chip.jsx
+++ b/src/components/ui/chip.jsx
@@ -31,6 +31,7 @@ const chipVariants = cva(
       variant: {
         primary: "bg-tertiary1-200 text-tertiary1-900",
         secondary: "bg-neutral-200 text-neutral-900",
+        custom: "",
       },
       interactive: {
         true: "hover:bg-neutral-300",
@@ -57,9 +58,11 @@ const Chip = ({
   variant = "secondary",
   interactive = true,
   disabled = false,
+  style,
 }) => {
   return (
     <div
+      style={style}
       className={cn(chipVariants({ variant, interactive, disabled }), className)}
       aria-disabled={disabled}
     >
@@ -96,9 +99,10 @@ Chip.propTypes = {
   onRemove: PropTypes.func,
   className: PropTypes.string,
   removable: PropTypes.bool,
-  variant: PropTypes.oneOf(["primary", "secondary"]),
+  variant: PropTypes.oneOf(["primary", "secondary", "custom"]),
   interactive: PropTypes.bool,
   disabled: PropTypes.bool,
+  style: PropTypes.object,
 };
 
 export default Chip;

--- a/src/components/ui/input-group.jsx
+++ b/src/components/ui/input-group.jsx
@@ -35,17 +35,26 @@ function InputGroup({
       data-slot="input-group"
       role="group"
       className={cn(
-        "group/input-group relative flex w-full items-center rounded-md border border-input shadow-xs transition-[color,box-shadow] outline-none dark:bg-input/30",
-        "h-9 min-w-0 has-[>textarea]:h-auto",
-        // Variants based on alignment.
+        "group/input-group relative flex w-full items-center",
+        "min-w-0 px-3 py-2",
+        "rounded",
+        "bg-white",
+        "border border-neutral-800",
+        "transition-colors",
+        "caret-primary",
+        "placeholder:text-neutral-800",
+
+        // active state exactly like Input.jsx
+        "has-[[data-slot=input-group-control]:focus-visible]:border-primary",
+        "has-[[data-slot=input-group-control]:focus-visible]:shadow-[0px_0px_3px_2px_#00449440]",
+        "has-[[data-slot=input-group-control]:focus-visible]:outline-none",
+
+        // alignment
         "has-[>[data-align=inline-start]]:[&>input]:pl-2",
         "has-[>[data-align=inline-end]]:[&>input]:pr-2",
         "has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-start]]:[&>input]:pb-3",
         "has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3",
-        // Focus state.
-        "has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-[3px] has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50",
-        // Error state.
-        "has-[[data-slot][aria-invalid=true]]:border-destructive has-[[data-slot][aria-invalid=true]]:ring-destructive/20 dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40",
+
         className
       )}
       {...props} />
@@ -148,7 +157,8 @@ function InputGroupInput({
     <Input
       data-slot="input-group-control"
       className={cn(
-        "flex-1 rounded-none border-0 bg-transparent shadow-none focus-visible:ring-0 dark:bg-transparent",
+        "flex-1 border-0 rounded-none bg-transparent shadow-none",
+        "focus-visible:ring-0 focus-visible:outline-none",
         className
       )}
       {...props} />

--- a/src/components/ui/popover.jsx
+++ b/src/components/ui/popover.jsx
@@ -1,0 +1,91 @@
+"use client"
+
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Popover({
+  ...props
+}) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />;
+}
+
+function PopoverTrigger({
+  ...props
+}) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          className
+        )}
+        {...props} />
+    </PopoverPrimitive.Portal>
+  );
+}
+
+function PopoverAnchor({
+  ...props
+}) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
+}
+
+function PopoverHeader({
+  className,
+  ...props
+}) {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn("flex flex-col gap-1 text-sm", className)}
+      {...props} />
+  );
+}
+
+function PopoverTitle({
+  className,
+  ...props
+}) {
+  return (
+    <div
+      data-slot="popover-title"
+      className={cn("font-medium", className)}
+      {...props} />
+  );
+}
+
+function PopoverDescription({
+  className,
+  ...props
+}) {
+  return (
+    <p
+      data-slot="popover-description"
+      className={cn("text-muted-foreground", className)}
+      {...props} />
+  );
+}
+
+export {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverAnchor,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverDescription,
+}

--- a/src/components/ui/scroll-area.jsx
+++ b/src/components/ui/scroll-area.jsx
@@ -1,0 +1,51 @@
+"use client"
+
+import * as React from "react"
+import { ScrollArea as ScrollAreaPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function ScrollArea({
+  className,
+  children,
+  ...props
+}) {
+  return (
+    <ScrollAreaPrimitive.Root data-slot="scroll-area" className={cn("relative", className)} {...props}>
+      <ScrollAreaPrimitive.Viewport
+        data-slot="scroll-area-viewport"
+        className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1">
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+      <ScrollBar />
+      <ScrollAreaPrimitive.Corner />
+    </ScrollAreaPrimitive.Root>
+  );
+}
+
+function ScrollBar({
+  className,
+  orientation = "vertical",
+  ...props
+}) {
+  return (
+    <ScrollAreaPrimitive.ScrollAreaScrollbar
+      data-slot="scroll-area-scrollbar"
+      orientation={orientation}
+      className={cn(
+        "flex touch-none p-px transition-colors select-none",
+        orientation === "vertical" &&
+          "h-full w-2.5 border-l border-l-transparent",
+        orientation === "horizontal" &&
+          "h-2.5 flex-col border-t border-t-transparent",
+        className
+      )}
+      {...props}>
+      <ScrollAreaPrimitive.ScrollAreaThumb
+        data-slot="scroll-area-thumb"
+        className="relative flex-1 rounded-full bg-border" />
+    </ScrollAreaPrimitive.ScrollAreaScrollbar>
+  );
+}
+
+export { ScrollArea, ScrollBar }

--- a/src/constants/endpoints.js
+++ b/src/constants/endpoints.js
@@ -163,6 +163,18 @@ const endpoints = {
   maintenance: {
     run: () => withBase("/maintenance"),
   },
+
+  // Obligations
+  obligations: {
+    //create: () => yet to expose endpoint
+    getList: () => withBase("/obligations/list"),
+    getAll: () => withBase("/obligations"),
+    getById: (id) => withBase(`/obligations/${id}`),
+    exportCsv: () => withBase("/obligations/export-csv"),
+    exportJson: () => withBase("/obligations/export-json"),// api endpoint not exposed
+    importJson: () => withBase("/obligations/import-csv"),
+    importCsv: () => withBase("/obligations/import-json"),// api endpoint not exposed
+  },
 };
 
 export default endpoints;

--- a/src/services/obligation.js
+++ b/src/services/obligation.js
@@ -1,0 +1,65 @@
+/*
+ SPDX-FileCopyrightText: 2026 Tiyasa Kundu (tiyasakundu20@gmail.com)
+
+SPDX-License-Identifier: GPL-2.0-only
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+import {
+    getObligationsListApi,
+    getAllObligationsApi,
+    getObligationByIdApi,
+    createObligationApi,
+    deleteObligationApi,
+    importObligationCsvApi,
+    importObligationJsonApi,
+    exportObligationCsvApi,
+    exportObligationJsonApi,
+} from "@/api/obligation";
+
+export const getObligationsList = async () => {
+    return await getObligationsListApi();
+};
+
+export const getAllObligations = async () => {
+    return await getAllObligationsApi();
+};
+
+export const getObligationById = async (id) => {
+    return await getObligationByIdApi(id);
+};
+
+export const createObligation = (data) => {
+    return createObligationApi(data).then((res) => res);
+};
+
+export const deleteObligation = async (id) => {
+    return await deleteObligationApi(id);
+};
+
+export const importObligationCsv = (formData) => {
+  return importObligationCsvApi(formData).then((res) => res);
+};
+// api endpoints not implemented
+export const importObligationJson = (formData) => {
+  return importObligationJsonApi(formData).then((res) => res);
+};
+
+export const exportObligationCsv = (id = 0) => {
+    return exportObligationCsvApi(id);
+};
+// api endpoints not implemented
+export const exportObligationJson = (id = 0) => {
+    return exportObligationJsonApi(id);
+};


### PR DESCRIPTION
## Description

Implement Obligation Admin Pages

### Changes

- Implement admin -> obligation administration pages which include:
   - Add Obligation page
   - Select Obligation page
   - Operations Page
   - Operations page -> JSON export button, CSV export button, Obligation import button
   - Obligation import page
   
- Implemented a custom variant for the chip ui component to be able to use non interactive chip/tags and apply custom colors

- Implemented a reusable Searchable Multi Select component 

- Refactor the existing code to improve component structure, API handling, and code reuse

Related to #402 