### PR TITLE
feat(nextjs): wire up group rename to new OpenAPI v2 endpoint

### DIFF
--- a/src/api/groups.js
+++ b/src/api/groups.js
@@ -74,3 +74,18 @@ export const deleteGroupApi = (name) => {
     addGroupName: false,
   });
 };
+
+// PATCH /groups/{name}  body: { name: newName }
+export const editGroupApi = (name, newName) => {
+  return sendRequest({
+    url: endpoints.groups.updateByName(name),
+    method: "PATCH",
+    headers: {
+      Authorization: getToken(),
+    },
+    body: {
+      name: newName,
+    },
+    addGroupName: false,
+  });
+};

--- a/src/app/admin/group/edit/EditGroupClient.jsx
+++ b/src/app/admin/group/edit/EditGroupClient.jsx
@@ -36,7 +36,7 @@ import {
 } from "@/components/ui/select";
 
 // API Services
-import { fetchAllGroups } from "@/services/groups";
+import { editGroup, fetchAllDeletableGroups } from "@/services/groups";
 
 // Helper
 import { handleError } from "@/shared/helper";
@@ -50,11 +50,16 @@ const EditGroupClient = () => {
   const [showMessage, setShowMessage] = useState(false);
   const [message, setMessage] = useState({ type: "success", text: "" });
 
+  const loadGroups = () => {
+    return fetchAllDeletableGroups().then((res) => {
+      const groupList = Array.isArray(res) ? res : [];
+      setGroups(groupList);
+      return groupList;
+    });
+  };
+
   useEffect(() => {
-    fetchAllGroups()
-      .then((res) => {
-        setGroups(Array.isArray(res) ? res : []);
-      })
+    loadGroups()
       .catch((error) => {
         handleError(error, setMessage);
         setShowMessage(true);
@@ -74,17 +79,25 @@ const EditGroupClient = () => {
 
   const handleSubmit = (e) => {
     e.preventDefault();
+    const selectedGroup = groups.find(
+      (g) => g.id.toString() === selectedGroupId.toString()
+    );
+    if (!selectedGroup) return;
 
-    // TODO:
-    // FOSSology API v2 does not provide a Group Rename endpoint.
-    // Re-enable this handler once the backend exposes a rename API.
-
-    setMessage({
-      type: "info",
-      text: "Group renaming is currently unavailable because the API endpoint is not implemented in FOSSology API v2.",
-    });
-
-    setShowMessage(true);
+    setLoading(true);
+    editGroup(selectedGroup.name, groupName.trim())
+      .then(() => {
+        setMessage({ type: "success", text: messages.renamedGroup });
+        setSelectedGroupId("");
+        return loadGroups();
+      })
+      .catch((error) => {
+        handleError(error, setMessage);
+      })
+      .finally(() => {
+        setLoading(false);
+        setShowMessage(true);
+      });
   };
 
   const alertType =
@@ -127,7 +140,7 @@ const EditGroupClient = () => {
               Loading groups…
             </div>
           ) : groups.length === 0 ? (
-            <p className="text-sm text-gray-500">No groups available.</p>
+            <p className="text-sm text-gray-500">No groups available for editing.</p>
           ) : (
             <Select
               value={selectedGroupId?.toString()}

--- a/src/constants/endpoints.js
+++ b/src/constants/endpoints.js
@@ -121,6 +121,8 @@ const endpoints = {
     create: () => withBase("/groups"),
     deleteByName: (name) =>
       withBase(`/groups/${encodeURIComponent(name)}`),
+    updateByName: (name) =>
+      withBase(`/groups/${encodeURIComponent(name)}`),
     members: (name) =>
       withBase(`/groups/${encodeURIComponent(name)}/members`),
     addUser: (name, userName) =>

--- a/src/constants/messages.js
+++ b/src/constants/messages.js
@@ -25,6 +25,7 @@ const messages = {
   noPageLong: "We could not find the page you were searching for",
   groupCreate: "Successfully created the group",
   deletedGroup: "Successfully deleted the group",
+  renamedGroup: "Successfully renamed the group",
   deletedUser: "Successfully deleted the user",
   addedUser: "Successfully added the user",
   confirmDeletion: "Deletion not confirmed",

--- a/src/services/groups.js
+++ b/src/services/groups.js
@@ -21,12 +21,13 @@ SPDX-License-Identifier: GPL-2.0-only
 // ─────────────────────────────────────────────────────────────────────────────
 // CHANGES v1 → v2
 // • deleteGroup(id)  → deleteGroup(name)  — now passes group name, not integer id
-// • editGroup        → REMOVED            — no v2 endpoint exists for renaming
+// • editGroup(id, newName) → editGroup(name, newName) — now passes group name, not integer id
 // ─────────────────────────────────────────────────────────────────────────────
 import {
   getAllGroupsApi,
   createGroupApi,
   deleteGroupApi,
+  editGroupApi,
   getAllDeletableGroupsApi,
 } from "@/api/groups";
 import { setLocalStorage, getLocalStorage } from "@/shared/storageHelper";
@@ -54,4 +55,6 @@ export const fetchAllDeletableGroups = () => {
   return getAllDeletableGroupsApi().then((res) => res);
 };
 
-// editGroup is REMOVED — v2 has no group-rename REST endpoint.
+export const editGroup = (name, newName) => {
+  return editGroupApi(name, newName).then((res) => res);
+};


### PR DESCRIPTION
## Description

FOSSology API v2 had no endpoint to rename an existing group, even though the legacy PHP UI provides one (`AdminGroupEdit`). This blocked the Edit Group page in the React/Next.js migration — it was already built and wired for the UI/UX, but stubbed out with "Group renaming is currently unavailable" since there was nothing to call. This PR wires that page up now that the backend exposes `PATCH /groups/{name}`.

### Changes

- Added `editGroupApi` in `src/api/groups.js` — calls `PATCH /groups/{name}` with `{ name: newName }` in the request body.
- Added `editGroup` service wrapper in `src/services/groups.js`.
- Added `updateByName` endpoint constant in `src/constants/endpoints.js`.
- Added `renamedGroup` success message in `src/constants/messages.js`.
- Updated `EditGroupClient.jsx`:
  - Replaced the stubbed "unavailable" submit handler with a real call to `editGroup`.
  - Switched the group list source from `fetchAllGroups` to `fetchAllDeletableGroups`, so only groups the current user is actually authorized to rename are selectable (matches the backend's admin-only check).
  - Shows a success/error `AlertBanner` and refreshes the group list after a rename.

## How to test

1. Requires the companion backend change adding `PATCH /groups/{name}` (`fossology` repo) to be running on the API server this UI points at.
2. Log in as an admin (or a user who is admin of at least one group).
3. Go to `Admin → Groups → Add Group` and create a test group.
4. Go to `Admin → Groups → Edit Group`.
5. Select the test group from the dropdown, enter a new name, and click **Update**.
6. Confirm the "Successfully renamed the group" banner appears and the dropdown now shows the new name.
7. Try renaming to a numeric-only name, or to an existing group's name — confirm the backend's validation error is shown instead of a silent failure.

Closes #422
