### PR TITLE
feat(nextjs): show last maintenance run on Admin > Maintenance page

### DIFF
--- a/src/api/maintenance.js
+++ b/src/api/maintenance.js
@@ -35,3 +35,13 @@ export const createMaintenanceApi = (body) =>
     },
     body,
   });
+
+// Getting details about the last completed maintenance job
+export const getMaintenanceInfoApi = () =>
+  sendRequest({
+    url: endpoints.maintenance.info(),
+    method: "GET",
+    headers: {
+      Authorization: getToken(),
+    },
+  });

--- a/src/app/admin/maintenance/MaintenanceClient.jsx
+++ b/src/app/admin/maintenance/MaintenanceClient.jsx
@@ -18,12 +18,12 @@ SPDX-License-Identifier: GPL-2.0-only
 
 "use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
 // External Links
 import externalLinks from "@/constants/externalLinks";
 
-import { createMaintenance } from "@/services/maintenance";
+import { createMaintenance, getMaintenanceInfo } from "@/services/maintenance";
 import {
   maintenanceOptions,
   initialMaintenanceFields,
@@ -44,6 +44,19 @@ const ManageMaintenance = () => {
   const [fields, setFields] = useState(initialMaintenanceFields);
   const [showMessage, setShowMessage] = useState(false);
   const [message, setMessage] = useState(initialMessage);
+  const [lastRun, setLastRun] = useState(null);
+
+  useEffect(() => {
+    getMaintenanceInfo()
+      .then((res) => setLastRun(res?.lastRun ?? null))
+      .catch(() => setLastRun(null));
+  }, []);
+
+  const formatLastRun = (date) =>
+    new Date(date).toLocaleString("en-US", {
+      dateStyle: "long",
+      timeStyle: "short",
+    });
 
   const handleChange = (value, name) => {
     if (name === "logsDate" || name === "goldDate") {
@@ -112,6 +125,15 @@ const ManageMaintenance = () => {
           <h1 className="text-2xl font-semibold text-gray-900 mb-6">
             FOSSology Maintenance
           </h1>
+          {lastRun && (
+            <div className="mb-4">
+              <AlertBanner
+                type="Info"
+                description={`Last maintenance job was executed on ${formatLastRun(lastRun)}`}
+                showClose={false}
+              />
+            </div>
+          )}
           <form
             onSubmit={handleSubmit}
             className="space-y-7"

--- a/src/app/admin/maintenance/MaintenanceClient.jsx
+++ b/src/app/admin/maintenance/MaintenanceClient.jsx
@@ -29,6 +29,7 @@ import {
   initialMaintenanceFields,
   initialMessage,
 } from "@/constants/constants";
+import { isAdmin } from "@/shared/authHelper";
 
 import { AlertBanner } from "@/components/ui/alert";
 import { Input } from "@/components/ui/input";
@@ -47,6 +48,9 @@ const ManageMaintenance = () => {
   const [lastRun, setLastRun] = useState(null);
 
   useEffect(() => {
+    if (!isAdmin()) {
+      return;
+    }
     getMaintenanceInfo()
       .then((res) => setLastRun(res?.lastRun ?? null))
       .catch(() => setLastRun(null));

--- a/src/constants/endpoints.js
+++ b/src/constants/endpoints.js
@@ -162,6 +162,7 @@ const endpoints = {
   // Maintenance
   maintenance: {
     run: () => withBase("/maintenance"),
+    info: () => withBase("/maintenance"),
   },
 };
 

--- a/src/services/maintenance.js
+++ b/src/services/maintenance.js
@@ -17,7 +17,10 @@ SPDX-License-Identifier: GPL-2.0-only
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-import { createMaintenanceApi } from "@/api/maintenance";
+import { createMaintenanceApi, getMaintenanceInfoApi } from "@/api/maintenance";
 
 export const createMaintenance = (data) =>
   createMaintenanceApi(data);
+
+export const getMaintenanceInfo = () =>
+  getMaintenanceInfoApi();


### PR DESCRIPTION
Wires up GET /maintenance (added on the backend for fossology/fossology#427) to the Admin > Maintenance page, so the new UI displays the last successfully completed maintenance job's timestamp, matching the legacy PHP admin page.

Refs: fossology/FOSSologyUI#427

## Description

Adds a "Last maintenance job was executed on ..." info banner to the Admin > Maintenance page, matching the legacy PHP admin page's behavior. This is backed by a new `GET /maintenance` endpoint on the backend (companion PR: `fossology/fossology`, branch `feat/427-maintenance-last-run-api-v2`).

### Changes

- Add `endpoints.maintenance.info()`, `getMaintenanceInfoApi`, and `getMaintenanceInfo` service wrapper
- Fetch maintenance info on mount in `MaintenanceClient.jsx` (gated behind `isAdmin()`, since the endpoint is admin-only) and show an info banner when a previous run exists
- Fails silently if the endpoint call fails, so the page still works even before the backend change is deployed

## How to test

1. Ensure the backend has the companion `GET /maintenance` endpoint deployed (fossology/fossology, branch `feat/427-maintenance-last-run-api-v2`)
2. Log in as an admin and navigate to Admin > Maintenance
3. If a maintenance job has completed previously, confirm an info banner appears above the form showing "Last maintenance job was executed on <date/time>"
4. If no maintenance job has ever run, confirm the banner is simply absent and the form still works as before
5. Submit a maintenance job, then reload the page and confirm the banner now reflects the new run

Closes fossology/FOSSologyUI#427
