### PR TITLE
feat(nextjs): Wire tag admin pages to create/enable-disable API

### DIFF
--- a/src/api/tags.js
+++ b/src/api/tags.js
@@ -1,0 +1,52 @@
+/*
+SPDX-License-Identifier: GPL-2.0-only
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+import endpoints from "@/constants/endpoints";
+
+// Getting Authorization Token
+import { getToken } from "@/shared/authHelper";
+
+// Function for calling the fetch function for the APIs
+import sendRequest from "./sendRequest";
+
+// POST /tags
+export const createTagApi = ({ name, description }) => {
+  return sendRequest({
+    url: endpoints.tags.create(),
+    method: "POST",
+    headers: {
+      Authorization: getToken(),
+    },
+    body: {
+      name,
+      description,
+    },
+  });
+};
+
+// PUT /uploads/{uploadId}/tags/display
+export const setTagDisplayStatusApi = ({ uploadId, enabled }) => {
+  return sendRequest({
+    url: endpoints.tags.setDisplayStatus(uploadId),
+    method: "PUT",
+    headers: {
+      Authorization: getToken(),
+    },
+    body: {
+      enabled,
+    },
+  });
+};

--- a/src/app/admin/tag/create/CreateTagClient.jsx
+++ b/src/app/admin/tag/create/CreateTagClient.jsx
@@ -25,27 +25,37 @@ import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { AlertBanner } from "@/components/ui/alert";
+import { createTag } from "@/services/tags";
 
 const CreateTagClient = () => {
   const [tagName, setTagName] = useState("");
   const [tagDescription, setTagDescription] = useState("");
   const [message, setMessage] = useState(null);
   const [showMessage, setShowMessage] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleSubmit = (e) => {
     e.preventDefault();
+    setIsSubmitting(true);
 
-    // TODO: Replace after API integration
-    setMessage({
-      type: "error",
-      text: "Create Tag API has not been implemented yet.",
-    });
-    setShowMessage(true);
-
-    console.log({
-      tagName,
-      tagDescription,
-    });
+    createTag({ name: tagName.trim(), description: tagDescription })
+      .then(() => {
+        setMessage({
+          type: "success",
+          text: `Tag '${tagName.trim()}' created successfully.`,
+        });
+        setShowMessage(true);
+        setTagName("");
+        setTagDescription("");
+      })
+      .catch((error) => {
+        setMessage({
+          type: "error",
+          text: error?.message || "Failed to create tag.",
+        });
+        setShowMessage(true);
+      })
+      .finally(() => setIsSubmitting(false));
   };
 
   const isFormValid = tagName.trim() !== "";
@@ -104,7 +114,7 @@ const CreateTagClient = () => {
 
         <Button
           type="submit"
-          disabled={!isFormValid}
+          disabled={!isFormValid || isSubmitting}
         >
           Create
         </Button>

--- a/src/app/admin/tag/enableDisable/EnableDisableClient.jsx
+++ b/src/app/admin/tag/enableDisable/EnableDisableClient.jsx
@@ -37,6 +37,7 @@ import {
   getAllFolders,
   getFolderContents,
 } from "@/services/folders";
+import { setTagDisplayStatus } from "@/services/tags";
 
 const EnableDisableClient = () => {
     const [folder, setFolder] = useState("");
@@ -45,6 +46,7 @@ const EnableDisableClient = () => {
     const [selectedUpload, setSelectedUpload] = useState(null);
     const [message, setMessage] = useState(null);
     const [showMessage, setShowMessage] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
 
     useEffect(() => {
         getAllFolders()
@@ -53,6 +55,8 @@ const EnableDisableClient = () => {
     }, []);
 
     useEffect(() => {
+        setSelectedUpload(null);
+
         if (!folder) {
             setUploads([]);
             return;
@@ -72,33 +76,30 @@ const EnableDisableClient = () => {
 
     const isFormValid = folder !== "" && selectedUpload !== null;
 
-    const handleDisable = () => {
-        // TODO: API Integration
-        setMessage({
-            type: "error",
-            text: "Enable/Disable Tag Display API has not been implemented yet.",
-        });
-        setShowMessage(true);
+    const handleToggle = (enabled) => {
+        setIsSubmitting(true);
 
-        console.log("Disable", {
-            folder,
-            upload: selectedUpload,
-        });
+        setTagDisplayStatus({ uploadId: selectedUpload, enabled })
+            .then(() => {
+                setMessage({
+                    type: "success",
+                    text: `Tag display ${enabled ? "enabled" : "disabled"} for the selected upload.`,
+                });
+                setShowMessage(true);
+            })
+            .catch((error) => {
+                setMessage({
+                    type: "error",
+                    text: error?.message || "Failed to update tag display status.",
+                });
+                setShowMessage(true);
+            })
+            .finally(() => setIsSubmitting(false));
     };
 
-    const handleEnable = () => {
-        // TODO: API Integration
-        setMessage({
-            type: "error",
-            text: "Enable/Disable Tag Display API has not been implemented yet.",
-        });
-        setShowMessage(true);
+    const handleDisable = () => handleToggle(false);
 
-        console.log("Enable", {
-            folder,
-            upload: selectedUpload,
-        });
-    };
+    const handleEnable = () => handleToggle(true);
 
     const alertType =
     message?.type === "danger" || message?.type === "error"
@@ -173,12 +174,12 @@ const EnableDisableClient = () => {
                             <button
                             key={upload.id}
                             type="button"
-                            onClick={() => setSelectedUpload(upload.id)}
+                            onClick={() => setSelectedUpload(upload.uploadId)}
                             className={`
                                 w-full rounded-sm px-2 py-1.5 text-left text-sm
                                 outline-none transition-colors
                                 ${
-                                selectedUpload === upload.id
+                                selectedUpload === upload.uploadId
                                     ? "bg-secondary text-gray-900"
                                     : "text-foreground hover:bg-secondary hover:text-gray-900 focus:bg-secondary focus:text-gray-900"
                                 }
@@ -196,7 +197,7 @@ const EnableDisableClient = () => {
                 type="button"
                 variant="alert-outline"
                 onClick={handleDisable}
-                disabled={!isFormValid}
+                disabled={!isFormValid || isSubmitting}
             >
                 Disable
             </Button>
@@ -205,7 +206,7 @@ const EnableDisableClient = () => {
                 type="button"
                 variant="success-outline"
                 onClick={handleEnable}
-                disabled={!isFormValid}
+                disabled={!isFormValid || isSubmitting}
             >
                 Enable
             </Button>

--- a/src/constants/endpoints.js
+++ b/src/constants/endpoints.js
@@ -163,6 +163,12 @@ const endpoints = {
   maintenance: {
     run: () => withBase("/maintenance"),
   },
+
+  // Tags
+  tags: {
+    create: () => withBase("/tags"),
+    setDisplayStatus: (uploadId) => withBase(`/uploads/${uploadId}/tags/display`),
+  },
 };
 
 export default endpoints;

--- a/src/services/tags.js
+++ b/src/services/tags.js
@@ -1,0 +1,27 @@
+/*
+SPDX-License-Identifier: GPL-2.0-only
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+import { createTagApi, setTagDisplayStatusApi } from "@/api/tags";
+
+// Creating a tag
+export const createTag = ({ name, description }) => {
+  return createTagApi({ name, description }).then((res) => res);
+};
+
+// Enabling or disabling the tag display for an upload
+export const setTagDisplayStatus = ({ uploadId, enabled }) => {
+  return setTagDisplayStatusApi({ uploadId, enabled }).then((res) => res);
+};


### PR DESCRIPTION
## Description

Admin > Tag > Create Tag and Enable/Disable Tag Display showed "API has not
been implemented yet" stubs since the backend had no matching endpoints.
Wires both pages to the new tag endpoints added on the backend (a companion
PR to fossology/fossology), and fixes an upload-identification bug in the
enable/disable flow along the way.

### Changes

- Adds `src/api/tags.js` and `src/services/tags.js`, the client layer for
  `POST /tags` (create) and `PUT /uploads/{id}/tags/display`
  (enable/disable), following the existing `api/`/`services/` split used by
  the rest of the app.
- Adds `endpoints.tags.create()` and `endpoints.tags.setDisplayStatus(uploadId)`
  to `src/constants/endpoints.js`.
- `CreateTagClient.jsx`: submit now calls `createTag()` instead of showing
  a static "not implemented" message; shows a real success/error banner,
  clears the form on success, and disables the button while the request is
  in flight.
- `EnableDisableClient.jsx`: Enable/Disable now call `setTagDisplayStatus()`
  instead of stub handlers.
  - Fixes upload selection: it was using the folder content's `id`
    (`foldercontents_pk`) as the upload identifier, which is a different
    value from the upload's actual id and would have targeted the wrong
    upload. Switches to the new `uploadId` field returned by the folder
    contents endpoint.
  - Resets the selected upload whenever the folder dropdown changes, so a
    stale selection from a previously chosen folder can't be submitted
    against the newly chosen one.

## How to test

1. Requires the backend changes from fossology/fossology (adds `POST /tags`
   and `PUT /uploads/{id}/tags/display`) to be running; point
   `NEXT_PUBLIC_SERVER_URL` at that instance and log in as an admin user.
2. Create Tag (`/admin/tag/create`): enter a name (letters/digits/
   `_~-!@#$%^*.()` only, no spaces, ≤32 chars) and optional description,
   click Create. Expect a success banner and the form to clear. Submitting
   the same name again should show the "already exists" error from the
   backend.
3. Enable/Disable Tag Display (`/admin/tag/enableDisable`): pick a folder,
   pick an upload, click Disable then Enable. Expect a success banner each
   time. Then pick a different folder, and without selecting an upload in
   it, confirm the Enable/Disable buttons are disabled (regression check
   for the stale-selection fix).
4. Confirm on the backend (`SELECT * FROM tag_manage WHERE upload_fk =
   <uploadId>;`) that Disable/Enable actually toggled the row for the
   upload you selected, not a different one.

Fixes #437.